### PR TITLE
Show the allowed-domain regex in the URL input placeholder

### DIFF
--- a/server/locales/ar.json
+++ b/server/locales/ar.json
@@ -14,7 +14,7 @@
   "index.tab.settings.connectivity": "الاتصال",
   "index.tab.settings.device": "جهاز",
   "index.tab.settings.iterations": "التكرارات",
-  "index.tab.settings.placeholder": "أدخل عنوان URL، مثل https://www.sitespeed.io",
+  "index.tab.settings.placeholder": "أدخل عنوان URL يطابق اسم مضيفه %s",
   "index.tab.cli.addargs": "إضافة وسائط",
   "index.tab.cli.clioptions": "خيارات",
   "index.tab.cli.placeholder": "وسيطات إضافية لـ sitespeed.io",

--- a/server/locales/bn.json
+++ b/server/locales/bn.json
@@ -14,7 +14,7 @@
   "index.tab.settings.connectivity": "নেটওয়ার্ক",
   "index.tab.settings.device": "ডিভাইস",
   "index.tab.settings.iterations": "ইটারেশন",
-  "index.tab.settings.placeholder": "একটি URL দিন, যেমন https://www.sitespeed.io",
+  "index.tab.settings.placeholder": "একটি URL দিন যার হোস্টনেম %s এর সাথে মেলে",
   "index.tab.cli.addargs": "CLI আর্গ যোগ",
   "index.tab.cli.clioptions": "অপশন",
   "index.tab.cli.placeholder": "অতিরিক্ত sitespeed.io আর্গুমেন্ট",

--- a/server/locales/de.json
+++ b/server/locales/de.json
@@ -14,7 +14,7 @@
   "index.tab.settings.connectivity": "Verbindung",
   "index.tab.settings.device": "Gerät",
   "index.tab.settings.iterations": "Wiederholungen",
-  "index.tab.settings.placeholder": "Geben Sie eine URL ein, z. B. https://www.sitespeed.io",
+  "index.tab.settings.placeholder": "Geben Sie eine URL ein, deren Hostname zu %s passt",
   "index.tab.cli.addargs": "Kommandozeilenargumente hinzufügen",
   "index.tab.cli.clioptions": "Optionen",
   "index.tab.cli.placeholder": "Zusätzliche sitespeed.io-Argumente",

--- a/server/locales/en.json
+++ b/server/locales/en.json
@@ -14,7 +14,7 @@
   "index.tab.settings.connectivity": "Connectivity",
   "index.tab.settings.device": "device",
   "index.tab.settings.iterations": "Iterations",
-  "index.tab.settings.placeholder": "Enter a URL like https://www.sitespeed.io",
+  "index.tab.settings.placeholder": "Enter a URL whose hostname matches %s",
   "index.tab.cli.addargs": "Add command line args",
   "index.tab.cli.clioptions": "options",
   "index.tab.cli.placeholder": "extra sitespeed.io arguments",

--- a/server/locales/es.json
+++ b/server/locales/es.json
@@ -14,7 +14,7 @@
   "index.tab.settings.connectivity": "Conectividad",
   "index.tab.settings.device": "Dispositivo",
   "index.tab.settings.iterations": "Iteraciones",
-  "index.tab.settings.placeholder": "Introduce una URL, p. ej. https://www.sitespeed.io",
+  "index.tab.settings.placeholder": "Introduce una URL cuyo nombre de host coincida con %s",
   "index.tab.cli.addargs": "Añadir args CLI",
   "index.tab.cli.clioptions": "Opciones",
   "index.tab.cli.placeholder": "Argumentos adicionales de sitespeed.io",

--- a/server/locales/fr.json
+++ b/server/locales/fr.json
@@ -14,7 +14,7 @@
   "index.tab.settings.connectivity": "Connectivité",
   "index.tab.settings.device": "Appareil",
   "index.tab.settings.iterations": "Itérations",
-  "index.tab.settings.placeholder": "Saisissez une URL, par exemple https://www.sitespeed.io",
+  "index.tab.settings.placeholder": "Saisissez une URL dont le nom d'hôte correspond à %s",
   "index.tab.cli.addargs": "Ajouter args CLI",
   "index.tab.cli.clioptions": "Options",
   "index.tab.cli.placeholder": "Arguments sitespeed.io supplémentaires",

--- a/server/locales/hi.json
+++ b/server/locales/hi.json
@@ -14,7 +14,7 @@
   "index.tab.settings.connectivity": "नेटवर्क",
   "index.tab.settings.device": "डिवाइस",
   "index.tab.settings.iterations": "दोहराव",
-  "index.tab.settings.placeholder": "एक URL दर्ज करें, जैसे https://www.sitespeed.io",
+  "index.tab.settings.placeholder": "एक URL दर्ज करें जिसका होस्टनेम %s से मेल खाता हो",
   "index.tab.cli.addargs": "आर्ग्स",
   "index.tab.cli.clioptions": "विकल्प",
   "index.tab.cli.placeholder": "अतिरिक्त sitespeed.io आर्ग्यूमेंट",

--- a/server/locales/pt.json
+++ b/server/locales/pt.json
@@ -14,7 +14,7 @@
   "index.tab.settings.connectivity": "Conectividade",
   "index.tab.settings.device": "Dispositivo",
   "index.tab.settings.iterations": "Iterações",
-  "index.tab.settings.placeholder": "Digite uma URL, por exemplo https://www.sitespeed.io",
+  "index.tab.settings.placeholder": "Digite uma URL cujo nome de host corresponda a %s",
   "index.tab.cli.addargs": "Adicionar args CLI",
   "index.tab.cli.clioptions": "Opções",
   "index.tab.cli.placeholder": "Argumentos adicionais do sitespeed.io",

--- a/server/locales/ru.json
+++ b/server/locales/ru.json
@@ -14,7 +14,7 @@
   "index.tab.settings.connectivity": "Соединение",
   "index.tab.settings.device": "Устр.",
   "index.tab.settings.iterations": "Итерации",
-  "index.tab.settings.placeholder": "Введите URL, например https://www.sitespeed.io",
+  "index.tab.settings.placeholder": "Введите URL, имя хоста которого соответствует %s",
   "index.tab.cli.addargs": "Добавить args CLI",
   "index.tab.cli.clioptions": "Опции",
   "index.tab.cli.placeholder": "Дополнительные аргументы sitespeed.io",

--- a/server/locales/ur.json
+++ b/server/locales/ur.json
@@ -14,7 +14,7 @@
   "index.tab.settings.connectivity": "کنیکٹیویٹی",
   "index.tab.settings.device": "ڈیوائس",
   "index.tab.settings.iterations": "تکرار",
-  "index.tab.settings.placeholder": "URL درج کریں، مثلاً https://www.sitespeed.io",
+  "index.tab.settings.placeholder": "ایک URL درج کریں جس کا ہوسٹ نیم %s سے میل کھاتا ہو",
   "index.tab.cli.addargs": "CLI آرگز شامل کریں",
   "index.tab.cli.clioptions": "آپشنز",
   "index.tab.cli.placeholder": "اضافی sitespeed.io آرگیومنٹس",

--- a/server/locales/zh-CN.json
+++ b/server/locales/zh-CN.json
@@ -14,7 +14,7 @@
   "index.tab.settings.connectivity": "网络",
   "index.tab.settings.device": "设备",
   "index.tab.settings.iterations": "迭代次数",
-  "index.tab.settings.placeholder": "输入 URL,例如 https://www.sitespeed.io",
+  "index.tab.settings.placeholder": "输入主机名与 %s 匹配的 URL",
   "index.tab.cli.addargs": "添加命令行参数",
   "index.tab.cli.clioptions": "选项",
   "index.tab.cli.placeholder": "额外的 sitespeed.io 参数",

--- a/server/views/includes/index/tabs/settings.pug
+++ b/server/views/includes/index/tabs/settings.pug
@@ -9,7 +9,7 @@ block content
     .field.is-grouped
         p.control.is-expanded
             label.sr-only(for='url') URL to test
-            input.input.is-medium(type='url' inputmode='url' placeholder=getText('index.tab.settings.placeholder') name='url' id='url' autofocus required aria-required='true' autocomplete='url' autocapitalize='off' spellcheck='false')
+            input.input.is-medium(type='url' inputmode='url' placeholder=getText('index.tab.settings.placeholder', testDomains) name='url' id='url' autofocus required aria-required='true' autocomplete='url' autocapitalize='off' spellcheck='false')
         p.control
             button.button.is-primary.is-medium(accesskey='s' id='submittest' type='submit')
               | #{getText('index.button.analyze')}


### PR DESCRIPTION
The URL placeholder used to read "Enter a URL like https://www.sitespeed.io", which is misleading on any server that restricts which hosts can be tested: the example URL is rejected and the user is left to guess what's allowed. Surface the configured validTestDomains regex directly in the placeholder so the constraint is visible at the point of input. Updated all locale files.

Co-authored-by: Claude noreply@anthropic.com