### PR TITLE
Fix broken status polling and missing fonts on the running page

### DIFF
--- a/server/src/static/index.js
+++ b/server/src/static/index.js
@@ -31,6 +31,13 @@ export function setupStatic(app) {
   );
 
   app.use(
+    '/fonts',
+    express.static(getBaseFilePath(path.join('public', 'fonts')), {
+      maxAge: '366 days'
+    })
+  );
+
+  app.use(
     '/compare',
     express.static(getBaseFilePath(path.join('public', 'compare')), {
       maxAge: '10 minutes'

--- a/server/src/static/index.js
+++ b/server/src/static/index.js
@@ -44,6 +44,12 @@ export function setupStatic(app) {
     })
   );
 
+  app.get('/sitespeed-help.json', (request, response) => {
+    response.sendFile(
+      getBaseFilePath(path.join('public', 'sitespeed-help.json'))
+    );
+  });
+
   if (nconf.get('html:extras:path')) {
     logger.info(
       'Setting up extra folder /extras to ' + nconf.get('html:extras:path')

--- a/server/views/includes/runningHead.pug
+++ b/server/views/includes/runningHead.pug
@@ -28,7 +28,7 @@ script(type='text/javascript').
   function worker() {
     const images = ['/img/ai/performance-engineers-healthy-relationship-to-google.jpg'];
     const texts = ['Performance Engineers healthy relationship to Google'];
-    const showRandomAIImage = !{JSON.stringify(nconf.get('html:showRandomAIImage'))};
+    const showRandomAIImage = !{JSON.stringify(nconf.get('html:showRandomAIImage') === true)};
     let xhr = new XMLHttpRequest();
     xhr.open("GET", "/api/status/#{id}", true);
     xhr.onload = function() {


### PR DESCRIPTION
Two regressions surfaced on the running test page: the JS that polls /api/status crashed with a SyntaxError, and every webfont 404'd.

The polling script reads html.showRandomAIImage from server config. When that key isn't set, JSON.stringify(undefined) returns undefined, which Pug interpolates as empty — emitting const showRandomAIImage = ; and killing the whole script. Coercing to a strict boolean before stringify keeps the output a valid JS literal regardless of how the server is configured.

Fonts moved to public/fonts/ with the theme refactor (#224) but no /fonts static route was ever wired up, so head.pug preloads and every @font-face request fell through to the 404 handler.

Co-authored-by: Claude noreply@anthropic.com