### PR TITLE
Fix spinning /result page when a queued test has dropped out of the i…

### DIFF
--- a/server/src/routes/html/result.js
+++ b/server/src/routes/html/result.js
@@ -115,6 +115,18 @@ result.get('/:id', async function (request, response) {
           getText
         });
       }
+    } else {
+      response.header('Cache-Control', 'no-cache, no-store, must-revalidate');
+      response.header('Pragma', 'no-cache');
+      response.header('Expires', 0);
+      return response.render('running', {
+        status: testResult.status,
+        message: '',
+        id: id,
+        url: testResult.url,
+        nconf,
+        getText
+      });
     }
   }
 });


### PR DESCRIPTION
…n-memory queue cache

The result route looks up the test's BullMQ queue via a NodeCache that has a 1-hour TTL (and is lost on server restart). When the lookup misses, the route falls back to reading the test from the database — but that fallback only knew how to respond when the status was completed or failed. For a test still in active (or waiting / stuck), the handler simply returned nothing and the browser sat spinning until it timed out.

The DB-fallback branch now renders the same running page as the queue branch when the status is non-terminal, so the client-side poller can take over and redirect once the test finishes.

Co-authored-by: Claude Opus 4.7 (1M context) noreply@anthropic.com