### PR TITLE
Load .env from the project root so npm start --prefix works

### DIFF
--- a/server/npm-shrinkwrap.json
+++ b/server/npm-shrinkwrap.json
@@ -27,7 +27,7 @@
         "node-cache": "5.1.2",
         "node-uuid": "1.4.8",
         "pg": "8.16.3",
-        "prom-client": "^15.1.3",
+        "prom-client": "15.1.3",
         "pug": "3.0.3",
         "response-time": "2.3.4",
         "unique-names-generator": "4.7.1",

--- a/server/src/config.js
+++ b/server/src/config.js
@@ -1,11 +1,25 @@
-import 'dotenv/config';
 import path from 'node:path';
 import fs from 'node:fs';
+import { fileURLToPath } from 'node:url';
 
+import dotenv from 'dotenv';
 import nconf from 'nconf';
 import yaml from 'js-yaml';
 
 import { getBaseFilePath } from './util/fileutil.js';
+
+// Load .env first from cwd (so running `node app.js` from the server
+// dir keeps working), then from the project root so the per-package
+// scripts (`npm start --prefix server`) pick up the single root .env
+// that the .env.example.local docs describe. dotenv calls are additive
+// and never overwrite already-set vars, so this is order-safe. In
+// Docker the root path doesn't resolve to a real file — env vars come
+// from docker-compose's env_file directive — and the call no-ops.
+dotenv.config({ quiet: true });
+dotenv.config({
+  quiet: true,
+  path: path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../.env')
+});
 
 const defaultConfig = getBaseFilePath('./config/server.yaml');
 

--- a/testrunner/src/config.js
+++ b/testrunner/src/config.js
@@ -1,11 +1,26 @@
-import 'dotenv/config';
 import fs from 'node:fs';
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
+import dotenv from 'dotenv';
 import nconf from 'nconf';
 import yaml from 'js-yaml';
 
 import { getBaseFilePath } from './utility.js';
+
+// Load .env first from cwd (so running `node app.js` from the
+// testrunner dir keeps working), then from the project root so the
+// per-package scripts (`npm start --prefix testrunner`) pick up the
+// single root .env that the .env.example.local docs describe. dotenv
+// calls are additive and never overwrite already-set vars, so this is
+// order-safe. In Docker the root path doesn't resolve to a real file
+// — env vars come from docker-compose's env_file directive — and the
+// call no-ops.
+dotenv.config({ quiet: true });
+dotenv.config({
+  quiet: true,
+  path: path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../.env')
+});
 
 const DEFAULT_CONFIG = getBaseFilePath('./config/testrunner.yaml');
 


### PR DESCRIPTION
Co-authored-by: Claude Opus 4.7 (1M context) noreply@anthropic.com