### PR TITLE
Memphis status pills + HTML_THEME env override

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -82,6 +82,12 @@ ADMIN_BASICAUTH_LOGIN=admin
 # The URL shown in the sitespeed.io HTML report to link back to the server.
 SITESPEED.IO_HTML_HOMEURL="http://127.0.0.1:3000/"
 
+# GUI skin. Two themes ship in the box:
+#   console — engineering-grade light/dark dashboard (IBM Plex). Default.
+#   memphis — playful pastel sticker-style (Familjen Grotesk + Archivo Black + Caveat).
+# Maps to `html.theme` in server.yaml; .env wins.
+HTML_THEME=console
+
 # ====================================
 # SERVER & TESTRUNNER DOCKER IMAGES
 # ====================================

--- a/.env.example.local
+++ b/.env.example.local
@@ -72,6 +72,12 @@ LOCALIZATION_LOCALE=en
 ADMIN_BASICAUTH_LOGIN=admin
 SITESPEED.IO_HTML_HOMEURL="http://127.0.0.1:3000/"
 
+# GUI skin. Two themes ship in the box:
+#   console — engineering-grade light/dark dashboard (IBM Plex). Default.
+#   memphis — playful pastel sticker-style (Familjen Grotesk + Archivo Black + Caveat).
+# Maps to `html.theme` in server.yaml; .env wins.
+HTML_THEME=console
+
 # ====================================
 # TESTRUNNER
 # ====================================

--- a/server/public/css/extra-memphis.css
+++ b/server/public/css/extra-memphis.css
@@ -645,6 +645,56 @@ td.run-date { white-space: nowrap; }
 
 .has-text-success { color: var(--green); font-weight: 700; }
 .has-text-danger { color: var(--red); font-weight: 700; }
+
+/* Status badges in the search results — match the pill treatment the
+   console theme uses, in Memphis flavour (sticker border + shadow,
+   pastel fill). Applied only inside table cells so the plain class
+   above stays available for inline labels elsewhere. */
+td a.has-text-success,
+td span.has-text-success {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 2px 10px;
+  border: 2px solid var(--ink);
+  border-radius: 999px;
+  background: var(--pastel-mint);
+  color: var(--green);
+  font-family: var(--font-body);
+  font-weight: 700;
+  text-transform: lowercase;
+  box-shadow: 2px 2px 0 var(--ink);
+  text-decoration: none;
+}
+td a.has-text-success::before,
+td span.has-text-success::before {
+  content: "";
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--green);
+}
+td span.has-text-danger {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 2px 10px;
+  border: 2px solid var(--ink);
+  border-radius: 999px;
+  background: var(--pastel-pink);
+  color: var(--red);
+  font-family: var(--font-body);
+  font-weight: 700;
+  text-transform: lowercase;
+  box-shadow: 2px 2px 0 var(--ink);
+}
+td span.has-text-danger::before {
+  content: "";
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--red);
+}
 .has-text-black { color: var(--ink); }
 .has-background-white { background: #fff; }
 .has-background-color { background: var(--paper); }


### PR DESCRIPTION
  The console theme already styles "completed" / "failed" badges in the
  search table as soft-coloured pills (green dot on mint, red dot on
  blush). Memphis was missing the matching treatment so completed runs
  read as plain green text and failed runs as plain red text — visually
  inconsistent with the rest of the Memphis sticker aesthetic. Now
  they're proper pastel-filled pills with the same ink border + offset
  shadow the rest of Memphis uses.

  Also expose the GUI skin to .env: HTML_THEME=console|memphis.
  Already wired through nconf's env loader (separator: '_',
  lowerCase: true → maps to html.theme in server.yaml); just needed
  discoverability in the two .env.example files. Works in Docker too —
  docker-compose.server.yml mounts the same .env via its env_file
  directive.

  Co-authored-by: Claude Opus 4.7 (1M context) noreply@anthropic.com