### PR TITLE
Cache-bust theme + admin CSS via ?v=

### DIFF
--- a/server/src/webserver.js
+++ b/server/src/webserver.js
@@ -2,6 +2,7 @@ import http from 'node:http';
 import { createSecureServer } from 'node:http2';
 
 import path from 'node:path';
+import { createRequire } from 'node:module';
 
 import express from 'express';
 import helmet from 'helmet';
@@ -95,6 +96,14 @@ function setupExpressServer() {
 
   app.set('view engine', 'pug');
   app.set('views', path.resolve(getBaseFilePath('./views')));
+
+  // Make the server version available to every pug render so the
+  // theme CSS / admin CSS link tags can stamp a `?v=…` cache-buster
+  // on their hrefs. The classic-script tags on the standalone-compare
+  // pages stamp themselves at build time; the templated pug pages
+  // need an in-process equivalent.
+  const require = createRequire(import.meta.url);
+  app.locals.serverVersion = require('../package.json').version;
 
   app.enable('view cache');
 

--- a/server/views/admin/index.pug
+++ b/server/views/admin/index.pug
@@ -5,7 +5,7 @@ html(lang='en')
     meta(name='viewport' content='width=device-width, initial-scale=1')
     title Queues — onlinetest
     link(rel='preload' as='font' type='font/woff2' href='/fonts/ibm-plex-sans-var.woff2' crossorigin)
-    link(rel='stylesheet' href='/css/admin.css')
+    link(rel='stylesheet' href='/css/admin.css' + (serverVersion ? '?v=' + serverVersion : ''))
     script.
       function confirmAndSubmit(queue) {
         if (confirm(`Are you sure you want to empty the queue: ${queue}?`)) {

--- a/server/views/includes/head.pug
+++ b/server/views/includes/head.pug
@@ -1,5 +1,6 @@
 - var theme = nconf.get('html:theme') || 'console'
 - var fontPreload = theme === 'memphis' ? '/fonts/familjen-grotesk-var.woff2' : '/fonts/ibm-plex-sans-var.woff2'
+- var v = serverVersion ? '?v=' + serverVersion : ''
 meta(charset='utf-8')
 meta(name='viewport' content='width=device-width, initial-scale=1')
 meta(name='color-scheme' content='light dark')
@@ -7,9 +8,9 @@ title #{title}
 link(rel='preload' as='font' type='font/woff2' href=fontPreload crossorigin)
 if (theme === 'memphis')
   link(rel='preload' as='font' type='font/woff2' href='/fonts/archivo-black-400.woff2' crossorigin)
-link(rel='stylesheet' href='/css/extra-' + theme + '.css')
+link(rel='stylesheet' href='/css/extra-' + theme + '.css' + v)
 if (nconf.get('html:css:override'))
-  link(rel='stylesheet' href=nconf.get('html:css:override'))
+  link(rel='stylesheet' href=nconf.get('html:css:override') + v)
 link(rel='apple-touch-icon' sizes='180x180' href=nconf.get('html:favicon-180:path'))
 link(rel='icon' type='image/png' sizes='32x32' href=nconf.get('html:favicon-32:path'))
 meta(name='description' content=description)

--- a/server/views/includes/runningHead.pug
+++ b/server/views/includes/runningHead.pug
@@ -1,5 +1,6 @@
 - var theme = nconf.get('html:theme') || 'console'
 - var fontPreload = theme === 'memphis' ? '/fonts/familjen-grotesk-var.woff2' : '/fonts/ibm-plex-sans-var.woff2'
+- var v = serverVersion ? '?v=' + serverVersion : ''
 meta(charset='utf-8')
 meta(name='viewport' content='width=device-width, initial-scale=1')
 meta(name='color-scheme' content='light dark')
@@ -7,9 +8,9 @@ title #{title}
 link(rel='preload' as='font' type='font/woff2' href=fontPreload crossorigin)
 if (theme === 'memphis')
   link(rel='preload' as='font' type='font/woff2' href='/fonts/archivo-black-400.woff2' crossorigin)
-link(rel='stylesheet' href='/css/extra-' + theme + '.css')
+link(rel='stylesheet' href='/css/extra-' + theme + '.css' + v)
 if (nconf.get('html:css:override'))
-  link(rel='stylesheet' href=nconf.get('html:css:override'))
+  link(rel='stylesheet' href=nconf.get('html:css:override') + v)
 noscript
   meta(http-equiv='refresh' content='30')
 link(rel='apple-touch-icon-precomposed' sizes='144x144' href='/img/ico/sitespeed.io-144.png')


### PR DESCRIPTION
  The classic compare scripts already get a build-time ?v=<buildId>
  stamp from Vite. The onlinetest pug pages had no equivalent, so a
  patch release that only touches the theme CSS (e.g. the recent
  Memphis status-badge fix) sits in browser caches until the unrelated
  30-day cache header expires.

  Expose the server's package.json version once via app.locals so
  every pug render gets it, then append ?v=… to the
  extra-.css, css.override, and admin.css link tags. Tied to
  the package version (not a per-build timestamp) so the URL only
  changes when a release ships and downstream HTTP caches stay
  effective in between.

  Co-authored-by: Claude Opus 4.7 (1M context) noreply@anthropic.com