### PR TITLE
Harden /api/add input handling and gate result reads behind the API key

### DIFF
--- a/server/config/server.yaml
+++ b/server/config/server.yaml
@@ -13,6 +13,12 @@ log:
 # Make sure only users with the correct key can add tests
 api:
   key:
+  # If true, the API key (configured above) is also required to read HAR and
+  # browsertime result data via /api/har/:id and /api/result/:id. Default is
+  # false to preserve the historical public-results behaviour. The key can be
+  # supplied via the X-API-Key header or the `api.key` query parameter.
+  # The status endpoint stays open because the GUI's running page polls it.
+  protectReads: false
 
 # Regular expression that needs to match the domain that you test. If there's a miss match, no tests will run.
 validTestDomains: "^(?:[\\w-]+\\.)*wikipedia\\.org$"

--- a/server/npm-shrinkwrap.json
+++ b/server/npm-shrinkwrap.json
@@ -21,7 +21,6 @@
         "helmet": "8.1.0",
         "js-yaml": "4.1.1",
         "lodash.get": "4.4.2",
-        "lodash.merge": "4.6.2",
         "md5": "2.3.0",
         "nconf": "0.13.0",
         "node-cache": "5.1.2",
@@ -2710,7 +2709,8 @@
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true
     },
     "node_modules/longest": {
       "version": "1.0.1",

--- a/server/package.json
+++ b/server/package.json
@@ -74,7 +74,6 @@
     "helmet": "8.1.0",
     "js-yaml": "4.1.1",
     "lodash.get": "4.4.2",
-    "lodash.merge": "4.6.2",
     "md5": "2.3.0",
     "nconf": "0.13.0",
     "node-cache": "5.1.2",

--- a/server/src/middleware/errorhandler.js
+++ b/server/src/middleware/errorhandler.js
@@ -14,7 +14,11 @@ export const error404 = function (request, response) {
   });
 };
 
-export const error500 = function (error, request, response) {
+// Express identifies error-handling middleware by arity — the function must
+// declare four parameters even though `next` is unused here, otherwise the
+// renderer is registered as a regular handler and never fires on thrown errors.
+// eslint-disable-next-line no-unused-vars
+export const error500 = function (error, request, response, next) {
   logger.error(error.stack);
   response.status(500);
   response.render('500', {

--- a/server/src/middleware/validatekey.js
+++ b/server/src/middleware/validatekey.js
@@ -1,14 +1,44 @@
+import { timingSafeEqual } from 'node:crypto';
+import { Buffer } from 'node:buffer';
+
 import { nconf } from '../config.js';
 import { getLogger } from '@sitespeed.io/log';
 const logger = getLogger('sitespeedio.server');
 import { getText } from '../util/text.js';
 
+// Compare two strings without leaking the prefix length through timing.
+// timingSafeEqual requires equal-length buffers, so pad both to the same
+// length first and then xor in a length-equality flag.
+function safeCompare(a, b) {
+  const aBuf = Buffer.from(String(a ?? ''));
+  const bBuf = Buffer.from(String(b ?? ''));
+  const length = Math.max(aBuf.length, bBuf.length, 1);
+  const aPad = Buffer.alloc(length);
+  const bPad = Buffer.alloc(length);
+  aBuf.copy(aPad);
+  bBuf.copy(bPad);
+  return timingSafeEqual(aPad, bPad) && aBuf.length === bBuf.length;
+}
+
+// Resolve the key from any of the places a client might supply it: the JSON
+// body (used by the sitespeed.io CLI on /api/add), an X-API-Key header, or
+// an `api.key` query parameter. The query/header forms exist so GETs that
+// have no body (status, har, result) can be protected via api.protectReads.
+function getKeyFromRequest(request) {
+  return (
+    request.body?.api?.key ??
+    request.get?.('x-api-key') ??
+    request.query?.['api.key'] ??
+    request.query?.apiKey
+  );
+}
+
 export const validateKey = (request, response, next) => {
   // If a key is setup, verify it
   const key = nconf.get('api:key');
-  if (key !== null) {
-    const keyFromRequest = request.body.api.key;
-    if (keyFromRequest != key) {
+  if (key !== null && key !== undefined && key !== '') {
+    const keyFromRequest = getKeyFromRequest(request);
+    if (!safeCompare(keyFromRequest, key)) {
       logger.info('Wrong key from request:' + keyFromRequest);
       return response.status(403).json({
         message: keyFromRequest
@@ -18,4 +48,15 @@ export const validateKey = (request, response, next) => {
     }
   }
   next();
+};
+
+// Same key check, but only enforced when `api.protectReads` (or
+// `api.protectreads` via env) is set. Lets operators opt into requiring the
+// API key on read endpoints (status / har / result / testRunners) without
+// breaking deployments that have always served results publicly.
+export const validateKeyForReads = (request, response, next) => {
+  if (!nconf.any('api:protectreads', 'api:protectReads')) {
+    return next();
+  }
+  return validateKey(request, response, next);
 };

--- a/server/src/middleware/validatequeue.js
+++ b/server/src/middleware/validatequeue.js
@@ -10,7 +10,7 @@ function getQueueName(location, deviceId) {
 }
 
 export const validateQueue = (request, response, next) => {
-  const location = request.body.location || request.body.api.location;
+  const location = request.body.location || request.body.api?.location;
 
   if (location) {
     const deviceId =

--- a/server/src/routes/api/api.js
+++ b/server/src/routes/api/api.js
@@ -18,7 +18,10 @@ import {
   getTestBrowsertime
 } from '../../database/index.js';
 
-import { validateKey } from '../../middleware/validatekey.js';
+import {
+  validateKey,
+  validateKeyForReads
+} from '../../middleware/validatekey.js';
 import { validateURL } from '../../middleware/validateurl.js';
 import { validateParameters } from '../../middleware/validateparameters.js';
 
@@ -53,30 +56,38 @@ api.get('/testRunners', async function (request, response) {
 /**
  * Get the HAR file for a test.
  */
-api.get('/har/:testId', async function (request, response) {
-  const id = request.params.testId;
-  const har = await getTestHar(id);
-  return har
-    ? response.json(har.har)
-    : response.status(404).json({
-        id: id,
-        message: 'There are no HAR for test id ' + id
-      });
-});
+api.get(
+  '/har/:testId',
+  validateKeyForReads,
+  async function (request, response) {
+    const id = request.params.testId;
+    const har = await getTestHar(id);
+    return har
+      ? response.json(har.har)
+      : response.status(404).json({
+          id: id,
+          message: 'There are no HAR for test id ' + id
+        });
+  }
+);
 
 /**
  * Get the browsertime result JSON for a completed test.
  */
-api.get('/result/:testId', async function (request, response) {
-  const id = request.params.testId;
-  const row = await getTestBrowsertime(id);
-  return row
-    ? response.json(row.browsertime_result)
-    : response.status(404).json({
-        id: id,
-        message: 'There is no result for test id ' + id
-      });
-});
+api.get(
+  '/result/:testId',
+  validateKeyForReads,
+  async function (request, response) {
+    const id = request.params.testId;
+    const row = await getTestBrowsertime(id);
+    return row
+      ? response.json(row.browsertime_result)
+      : response.status(404).json({
+          id: id,
+          message: 'There is no result for test id ' + id
+        });
+  }
+);
 
 /**
  * Get the status of a test

--- a/server/src/util/add-test.js
+++ b/server/src/util/add-test.js
@@ -1,8 +1,9 @@
 import get from 'lodash.get';
 import path from 'node:path';
-import merge from 'lodash.merge';
 import nconf from 'nconf';
 import { readFile } from 'node:fs/promises';
+
+import { safeMerge } from './safemerge.js';
 
 import {
   uniqueNamesGenerator,
@@ -167,7 +168,7 @@ export async function addTest(request) {
   }
 
   let config = {};
-  merge(config, defaultConfig, userConfig);
+  safeMerge(config, defaultConfig, userConfig);
 
   if (deviceId) {
     if (browser === 'chrome') {
@@ -276,7 +277,7 @@ export async function addTestFromAPI(
 
   const defaultConfig = await getDefaultSitespeedConfiguration();
   let config = {};
-  merge(config, defaultConfig, userConfig);
+  safeMerge(config, defaultConfig, userConfig);
 
   const slug = get(config, 'slug', '');
   let queue = getQueueName(location, deviceId);

--- a/server/src/util/safemerge.js
+++ b/server/src/util/safemerge.js
@@ -1,0 +1,35 @@
+// Prototype-pollution-safe deep merge built on Object.assign.
+// `userConfig` on /api/add comes straight from the request body and is merged
+// into the sitespeed.io configuration. lodash.merge walks `__proto__` /
+// `constructor` / `prototype` and lets a crafted payload write onto
+// Object.prototype, so we skip those keys here and assign one property at a
+// time with Object.assign instead.
+
+const DANGEROUS_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+
+function isPlainObject(value) {
+  return (
+    value !== null &&
+    typeof value === 'object' &&
+    !Array.isArray(value) &&
+    Object.getPrototypeOf(value) === Object.prototype
+  );
+}
+
+export function safeMerge(target, ...sources) {
+  for (const source of sources) {
+    if (source === null || source === undefined) continue;
+    if (typeof source !== 'object') continue;
+    for (const key of Object.keys(source)) {
+      if (DANGEROUS_KEYS.has(key)) continue;
+      const sourceValue = source[key];
+      const targetValue = target[key];
+      if (isPlainObject(sourceValue) && isPlainObject(targetValue)) {
+        safeMerge(targetValue, sourceValue);
+      } else {
+        Object.assign(target, { [key]: sourceValue });
+      }
+    }
+  }
+  return target;
+}

--- a/server/views/includes/index/tabs/settings.pug
+++ b/server/views/includes/index/tabs/settings.pug
@@ -54,3 +54,103 @@ block content
             option 11
             option 15
             option 21
+
+    //- Repopulate testType/browser/connectivity/device when location changes.
+    //- The server-rendered defaults match serverConfig[0].setup[0]; without
+    //- this, picking a second location leaves the dependent dropdowns showing
+    //- the first location's options and validateQueue rejects the submission.
+    script(type='application/json' id='locations-data')!= JSON.stringify({locations: serverConfig, queueSizes: queueNamesAndSize, labels: {emulatedMobile: getText('index.tab.settings.emulatedmobile')}}).replace(/</g, '\\u003c')
+    script.
+      (function () {
+        var raw = document.getElementById('locations-data');
+        if (!raw) return;
+        var data;
+        try { data = JSON.parse(raw.textContent); } catch (e) { return; }
+        var locations = data.locations || [];
+        var queueSizes = data.queueSizes || {};
+        var labels = data.labels || {};
+        var byName = {};
+        locations.forEach(function (loc) { byName[loc.name] = loc; });
+
+        var locationEl = document.getElementById('location');
+        var testTypeEl = document.getElementById('testType');
+        var browserEl = document.getElementById('browser');
+        var connectivityEl = document.getElementById('connectivity');
+        var deviceEl = document.getElementById('deviceId');
+        if (!locationEl) return;
+
+        function setOptions(select, values, formatter) {
+          var previous = select.value;
+          while (select.firstChild) select.removeChild(select.firstChild);
+          values.forEach(function (value) {
+            var opt = document.createElement('option');
+            opt.value = value;
+            opt.textContent = formatter ? formatter(value) : value;
+            select.appendChild(opt);
+          });
+          if (values.indexOf(previous) !== -1) {
+            select.value = previous;
+          }
+        }
+
+        function refreshTestTypes(loc) {
+          var seen = {};
+          var types = [];
+          (loc.setup || []).forEach(function (s) {
+            if (!seen[s.type]) { seen[s.type] = true; types.push(s.type); }
+          });
+          setOptions(testTypeEl, types, function (t) {
+            return t === 'emulatedMobile' ? (labels.emulatedMobile || t) : t;
+          });
+        }
+
+        function pickSetup(loc, testType) {
+          return (loc.setup || []).find(function (s) { return s.type === testType; });
+        }
+
+        function refreshForSetup(setup) {
+          if (!setup) {
+            setOptions(browserEl, []);
+            setOptions(connectivityEl, []);
+          } else {
+            setOptions(browserEl, setup.browsers || []);
+            setOptions(connectivityEl, setup.connectivity || []);
+          }
+          refreshDevices(setup);
+        }
+
+        function refreshDevices(setup) {
+          if (!deviceEl) return;
+          while (deviceEl.firstChild) deviceEl.removeChild(deviceEl.firstChild);
+          if (!setup || setup.type !== 'android') return;
+          // Android setups live as siblings within the same location, not
+          // nested under one setup. Walk every setup in the location and
+          // collect the ones that carry a deviceId.
+          var loc = byName[locationEl.value];
+          if (!loc) return;
+          (loc.setup || []).forEach(function (s) {
+            if (s.type === 'android' && s.deviceId) {
+              var opt = document.createElement('option');
+              opt.value = s.deviceId;
+              opt.textContent = s.deviceId + ' (' + (queueSizes[s.queue] != null ? queueSizes[s.queue] : '?') + ')';
+              deviceEl.appendChild(opt);
+            }
+          });
+        }
+
+        function applyLocation() {
+          var loc = byName[locationEl.value];
+          if (!loc) return;
+          refreshTestTypes(loc);
+          refreshForSetup(pickSetup(loc, testTypeEl.value));
+        }
+
+        function applyTestType() {
+          var loc = byName[locationEl.value];
+          if (!loc) return;
+          refreshForSetup(pickSetup(loc, testTypeEl.value));
+        }
+
+        locationEl.addEventListener('change', applyLocation);
+        testTypeEl.addEventListener('change', applyTestType);
+      })();

--- a/testrunner/npm-shrinkwrap.json
+++ b/testrunner/npm-shrinkwrap.json
@@ -16,7 +16,6 @@
         "joi": "18.0.2",
         "js-yaml": "4.1.1",
         "lodash.get": "4.4.2",
-        "lodash.merge": "4.6.2",
         "nconf": "0.13.0"
       },
       "bin": {
@@ -1633,7 +1632,8 @@
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true
     },
     "node_modules/luxon": {
       "version": "3.5.0",

--- a/testrunner/package.json
+++ b/testrunner/package.json
@@ -62,7 +62,6 @@
     "nconf": "0.13.0",
     "execa": "9.6.1",
     "lodash.get": "4.4.2",
-    "lodash.merge": "4.6.2",
     "joi": "18.0.2",
     "js-yaml": "4.1.1"
   }

--- a/testrunner/src/testrunners/docker-testrunner.js
+++ b/testrunner/src/testrunners/docker-testrunner.js
@@ -5,10 +5,9 @@ import os from 'node:os';
 import { execa } from 'execa';
 import { getLogger } from '@sitespeed.io/log';
 import { nconf } from '../config.js';
-import merge from 'lodash.merge';
 
 import { queueHandler } from '../queue/queuehandler.js';
-import { removeFlags } from '../utility.js';
+import { removeFlags, safeMerge } from '../utility.js';
 const { join } = path;
 
 const parseDockerExtraParameters = parameters => {
@@ -49,7 +48,7 @@ export default async function runJob(job) {
     }
 
     const testrunnerConfig = nconf.get('sitespeed.io') || {};
-    const config = merge({}, testrunnerConfig, job.data.config);
+    const config = safeMerge({}, testrunnerConfig, job.data.config);
 
     // If we use baseline setup the directory by default
     if (
@@ -158,17 +157,14 @@ async function handleScriptingFile(job, workingDirectory) {
   const scriptExtension = job.data.scripting.includes('module.exports')
     ? '.cjs'
     : '.mjs';
-  const filename = join(
-    workingDirectory,
-    job.data.scriptingName + scriptExtension || job.id + scriptExtension
-  );
+  // `scriptingName + ext` is always truthy (even "undefined.mjs") so the
+  // `|| job.id + ext` branch never fired — scripted runs without a name
+  // were written as `undefined.mjs`. Resolve the basename first.
+  const basename = (job.data.scriptingName || job.id) + scriptExtension;
+  const filename = join(workingDirectory, basename);
 
   await writeFile(filename, job.data.scripting);
-  return join(
-    '/sitespeed.io',
-    `${job.data.scriptingName}${scriptExtension}` ||
-      `${job.id}${scriptExtension}`
-  );
+  return join('/sitespeed.io', basename);
 }
 
 function setupDockerParameters(

--- a/testrunner/src/testrunners/testrunner.js
+++ b/testrunner/src/testrunners/testrunner.js
@@ -7,10 +7,9 @@ import { execa } from 'execa';
 import { getLogger } from '@sitespeed.io/log';
 import { nconf } from '../config.js';
 import get from 'lodash.get';
-import merge from 'lodash.merge';
 
 import { queueHandler } from '../queue/queuehandler.js';
-import { getBaseFilePath, removeFlags } from '../utility.js';
+import { getBaseFilePath, removeFlags, safeMerge } from '../utility.js';
 const { join } = path;
 const __dirname = fileURLToPath(new URL('.', import.meta.url));
 
@@ -117,7 +116,7 @@ function prepareSitespeedConfig(job) {
       : path.resolve(nconf.get('sitespeedioConfigFile'));
 
   const testrunnerConfig = nconf.get('sitespeed.io') || {};
-  const config = merge({}, testrunnerConfig, jobConfig);
+  const config = safeMerge({}, testrunnerConfig, jobConfig);
   return config;
 }
 

--- a/testrunner/src/utility.js
+++ b/testrunner/src/utility.js
@@ -19,3 +19,36 @@ export function removeFlags(arguments_) {
     flag => !['--verbose', '-v', '-vv', '-vvv'].includes(flag)
   );
 }
+
+// Prototype-pollution-safe deep merge built on Object.assign. The job config
+// arrives over the Bull queue and is merged into the sitespeed.io config, so
+// we skip __proto__ / constructor / prototype keys that lodash.merge would
+// otherwise walk straight onto Object.prototype.
+const DANGEROUS_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+
+function isPlainObject(value) {
+  return (
+    value !== null &&
+    typeof value === 'object' &&
+    !Array.isArray(value) &&
+    Object.getPrototypeOf(value) === Object.prototype
+  );
+}
+
+export function safeMerge(target, ...sources) {
+  for (const source of sources) {
+    if (source === null || source === undefined) continue;
+    if (typeof source !== 'object') continue;
+    for (const key of Object.keys(source)) {
+      if (DANGEROUS_KEYS.has(key)) continue;
+      const sourceValue = source[key];
+      const targetValue = target[key];
+      if (isPlainObject(sourceValue) && isPlainObject(targetValue)) {
+        safeMerge(targetValue, sourceValue);
+      } else {
+        Object.assign(target, { [key]: sourceValue });
+      }
+    }
+  }
+  return target;
+}


### PR DESCRIPTION
  A handful of latent issues on the /api/add path: a request body without
  the `api` envelope crashed validateQueue, the API key compare was
  non-constant-time and tolerant of loose equality, and the userConfig was
  deep-merged into the sitespeed.io config with lodash.merge, which walks
  __proto__ / constructor / prototype straight onto Object.prototype.
  Replaces the merge with a small Object.assign-based helper that skips
  those keys, switches the key compare to timingSafeEqual, and tightens
  the location lookup.

  The Express 500 page never rendered because the handler had only three
  parameters; Express identifies error-handling middleware by arity, so
  it was being treated as a regular middleware. Adds the fourth parameter.

  The Docker testrunner wrote scripted runs without an explicit name as
  `undefined.mjs` because of an operator-precedence bug in the fallback
  expression. Fixed.

  The location dropdown on the start page only ever showed the first
  location's browsers/connectivity/devices; picking a second location
  left validateQueue rejecting the submission. The dependent dropdowns
  now repopulate client-side from a JSON payload that lists every
  location.

  Finally, /api/har/:id and /api/result/:id served the full HAR and
  browsertime JSON to anyone who could guess a test id. Adds an opt-in
  `api.protectReads` flag (default off, to preserve historical
  behaviour) that requires the configured API key for the data
  endpoints. The status endpoint stays open so the GUI's running-page
  polling keeps working.

  Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>