### PR TITLE
Drain HTTP requests on SIGTERM instead of killing them cold

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -25,10 +25,24 @@ if (nconf.get('version')) {
 const server = new SitespeedioServer();
 server.start();
 
-const gracefulShutdown = async () => {
-  await server.stop();
-  process.exit(0);
+// First signal triggers graceful drain; a second signal during drain
+// short-circuits to immediate exit so an impatient operator (or a stuck
+// connection) can't keep the process alive forever.
+let shuttingDown = false;
+const gracefulShutdown = async signal => {
+  if (shuttingDown) {
+    console.error(`Received ${signal} again during shutdown — forcing exit`);
+    process.exit(1);
+  }
+  shuttingDown = true;
+  try {
+    await server.stop();
+    process.exit(0);
+  } catch (error) {
+    console.error('Error during shutdown', error);
+    process.exit(1);
+  }
 };
 
-process.on('SIGINT', gracefulShutdown);
-process.on('SIGTERM', gracefulShutdown);
+process.on('SIGINT', () => gracefulShutdown('SIGINT'));
+process.on('SIGTERM', () => gracefulShutdown('SIGTERM'));

--- a/server/config/server.yaml
+++ b/server/config/server.yaml
@@ -5,6 +5,11 @@ server:
   ssl:
     key:
     cert:
+  # On SIGTERM/SIGINT the HTTP server stops accepting new connections and
+  # waits this many milliseconds for in-flight requests to finish. After
+  # the timeout it force-closes remaining sockets so the process can exit.
+  shutdown:
+    timeoutMs: 30000
 
 # Configure the log.
 log:

--- a/server/src/server.js
+++ b/server/src/server.js
@@ -131,8 +131,8 @@ export class SitespeedioServer {
       throw error;
     }
 
-    const webserver = new WebServer();
-    await webserver.start();
+    this.webserver = new WebServer();
+    await this.webserver.start();
     await setupTestRunnerQueue();
     await setupResultQueue();
     // Tell the world that we are starting
@@ -141,6 +141,17 @@ export class SitespeedioServer {
 
   async stop() {
     logger.info('Closing down server');
+
+    // Stop accepting new HTTP requests and drain the in-flight ones before
+    // we tear down the database pool — otherwise a request mid-query will
+    // hit a closed pool and 500 just before the process exits.
+    if (this.webserver) {
+      try {
+        await this.webserver.stop();
+      } catch (error) {
+        logger.error('Error during HTTP server shutdown', error);
+      }
+    }
 
     // Close the queues?
 

--- a/server/src/webserver.js
+++ b/server/src/webserver.js
@@ -223,18 +223,48 @@ export class WebServer {
         key: fs.readFileSync(nconf.get('server:ssl:key')),
         cert: fs.readFileSync(nconf.get('server:ssl:cert'))
       };
-      const server = createSecureServer(sslOptions, this.app);
-      server.listen(port, () => {
+      this.server = createSecureServer(sslOptions, this.app);
+      this.server.listen(port, () => {
         logger.info('Web app listening on HTTPS :%s', port);
       });
     } else {
-      http.createServer(this.app).listen(port, () => {
+      this.server = http.createServer(this.app);
+      this.server.listen(port, () => {
         logger.info('Web app listening on :%s', port);
       });
     }
   }
 
+  // Stop accepting new connections and wait for in-flight requests to
+  // finish. If they don't finish within `server.shutdown.timeoutMs`, force
+  // the remaining sockets closed so the process can actually exit on a
+  // rolling restart.
   async stop() {
-    await this.app.close();
+    if (!this.server) return;
+    const timeoutMs =
+      nconf.any('server:shutdown:timeoutMs', 'server:shutdown:timeoutms') ??
+      30_000;
+    logger.info('Closing HTTP server (drain timeout %d ms)', timeoutMs);
+    await new Promise(resolve => {
+      let timer = setTimeout(() => {
+        timer = undefined;
+        logger.warn(
+          'Drain timeout hit; force-closing remaining HTTP connections'
+        );
+        if (typeof this.server.closeAllConnections === 'function') {
+          this.server.closeAllConnections();
+        }
+      }, timeoutMs);
+      this.server.close(error => {
+        if (timer) clearTimeout(timer);
+        if (error) {
+          logger.error('Error while closing HTTP server', error);
+        } else {
+          logger.info('HTTP server closed');
+        }
+        resolve();
+      });
+    });
+    this.server = undefined;
   }
 }


### PR DESCRIPTION
  Before: SIGTERM ran the shutdown chain, which ended in this.app.close() on an Express app object that has no close()
  method. The HTTP server was never told to stop — it just disappeared when process.exit(0) fired a few lines later,
  killing in-flight requests mid-response. Rolling restarts dropped traffic.

  Now the web server holds a reference to the real http.Server (or Http2SecureServer) and stop() calls its close() so
  the listener refuses new connections and waits for outstanding requests to finish before resolving. After a
  configurable drain timeout (server.shutdown.timeoutMs, default 30 s) any sockets still in flight get force-closed so
  the process can actually exit. A second SIGTERM/SIGINT during shutdown short-circuits to immediate exit for operators
   who'd rather not wait.

  The shutdown order also matters: HTTP server first, then DB pool. Otherwise a request mid-query would hit a closed
  pool and 500 just before the process exited.

  Co-authored-by: Claude Opus 4.7 (1M context) noreply@anthropic.com