### PR TITLE
Make running multiple testrunners observable and self-healing

### DIFF
--- a/deploy/PRODUCTION.md
+++ b/deploy/PRODUCTION.md
@@ -140,6 +140,18 @@ You will want to put a reverse proxy (Caddy, nginx, etc.) in front of port 3000 
     sudo modprobe ifb numifbs=1
     ```
 
+### Adding a third (or Nth) testrunner
+
+Each testrunner machine follows the same recipe as the first — clone the repo, write the same `.env` (point at the same `REDIS_HOST`, share the same `REDIS_PASSWORD`/`MINIO_*` secrets), then `docker compose -f deploy/docker-compose.production-testrunner.yml up -d`. The only thing that **must** differ between machines is `LOCATION_NAME` (or, on Android farms, the `deviceId` in `testrunner/config/testrunner.yaml`).
+
+Don't forget the iptables/firewall step: the server machine needs to accept Redis (6379), PostgreSQL (5432) and MinIO (9000) traffic from each new testrunner IP. Repeat the `ACCEPT` rules from the lock-down step for every additional runner.
+
+A few minutes after a runner boots it should appear under **Connected testrunners** on `/admin` with a green "fresh" badge. If it doesn't show up:
+
+- **Nothing in the table** — the testrunner couldn't reach Redis. Check `REDIS_HOST`/`REDIS_PASSWORD` and the firewall.
+- **Row shows up but stays "stale"** — the runner registered once but stopped heartbeating. Check the testrunner logs for Redis errors.
+- **Server logs `Testrunner queue collision: <hostA> and <hostB> both claim queue <name>`** — two runners chose the same `LOCATION_NAME` (plus `deviceId`, on Android). Bull hands work to whichever machine wins the race; results from one run can come from either host. Fix it by giving the new machine a unique `LOCATION_NAME` and restarting.
+
 ### Reverse proxy examples
 
 If you are running the multi-server setup you need your own reverse proxy in front of the server machine. Here are examples for Caddy and nginx.

--- a/server/public/css/admin.css
+++ b/server/public/css/admin.css
@@ -263,6 +263,76 @@ footer p { margin: 0; }
   .row-head .cell.action { display: none; }
 }
 
+.section-heading {
+  max-width: 980px;
+  margin: 0 auto 12px;
+  padding: 0 4px;
+  font-size: 13px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+.section-heading + .container { margin-bottom: 28px; }
+
+/* Five-column grid for the testrunners table. The base .row rule above
+   defaults to a four-column queue layout; this overrides it for the
+   testrunners container without disturbing the queue table. */
+[aria-label='Connected testrunners'] .row {
+  grid-template-columns: 48px 1fr 1fr 2fr 110px;
+}
+.cell.runner-host {
+  font-family: var(--font-mono);
+  font-size: 14px;
+  color: var(--text);
+  word-break: break-all;
+}
+.cell.runner-loc, .cell.runner-setup {
+  font-size: 13.5px;
+  color: var(--text);
+  word-break: break-word;
+}
+.cell.runner-seen {
+  font-family: var(--font-mono);
+  font-size: 13px;
+  text-align: right;
+  color: var(--text-faint);
+}
+.cell.runner-seen.is-fresh {
+  color: var(--success, #0a7d36);
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  justify-self: end;
+}
+.cell.runner-seen.is-fresh::before {
+  content: "";
+  width: 6px; height: 6px;
+  border-radius: 50%;
+  background: var(--success, #0a7d36);
+}
+.cell.runner-seen.is-stale {
+  color: var(--warning, #b06400);
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  justify-self: end;
+}
+.cell.runner-seen.is-stale::before {
+  content: "";
+  width: 6px; height: 6px;
+  border-radius: 50%;
+  background: var(--warning, #b06400);
+}
+
+@media (max-width: 700px) {
+  [aria-label='Connected testrunners'] .row {
+    grid-template-columns: 1fr;
+    gap: 4px;
+  }
+  [aria-label='Connected testrunners'] .row-head { display: none; }
+}
+
 @media (prefers-reduced-motion: reduce) {
   *, *::before, *::after {
     animation-duration: 0.01ms !important;

--- a/server/src/routes/html/admin/index.js
+++ b/server/src/routes/html/admin/index.js
@@ -7,18 +7,31 @@ import {
   getExistingQueueNames,
   getQueueSize
 } from '../../../queuehandler.js';
+import { getTestRunners } from '../../../testrunners.js';
 
 export const admin = Router();
 
-admin.get('/', async function (request, response) {
+async function buildAdminView() {
   const queues = getExistingQueueNames();
-  let queueSizes = {};
-
+  const queueSizes = {};
   for (const queueName of queues) {
-    const size = await getQueueSize(queueName);
-    queueSizes[queueName] = size;
+    queueSizes[queueName] = await getQueueSize(queueName);
   }
+  const now = Date.now();
+  const testRunners = getTestRunners().map(runner => ({
+    hostname: runner.hostname,
+    location: runner.name,
+    setup: runner.setup,
+    lastSeenAt: runner.lastSeenAt,
+    secondsSinceSeen: runner.lastSeenAt
+      ? Math.max(0, Math.round((now - runner.lastSeenAt) / 1000))
+      : undefined
+  }));
+  return { queues, queueSizes, testRunners };
+}
 
+admin.get('/', async function (request, response) {
+  const { queues, queueSizes, testRunners } = await buildAdminView();
   response.render('admin/index', {
     bodyId: 'index',
     title: getText('index.title'),
@@ -26,7 +39,8 @@ admin.get('/', async function (request, response) {
     nconf,
     getText,
     queues,
-    queueSizes
+    queueSizes,
+    testRunners
   });
 });
 
@@ -35,14 +49,7 @@ admin.post('/', async function (request, response) {
   const queue = await getExistingQueue(name);
   await queue.empty();
 
-  const queues = getExistingQueueNames();
-  let queueSizes = {};
-
-  for (const queueName of queues) {
-    const size = await getQueueSize(queueName);
-    queueSizes[queueName] = size;
-  }
-
+  const { queues, queueSizes, testRunners } = await buildAdminView();
   response.render('admin/index', {
     bodyId: 'index',
     title: getText('index.title'),
@@ -50,6 +57,7 @@ admin.post('/', async function (request, response) {
     nconf,
     getText,
     queues,
-    queueSizes
+    queueSizes,
+    testRunners
   });
 });

--- a/server/src/server.js
+++ b/server/src/server.js
@@ -9,7 +9,12 @@ import {
   getExistingQueue,
   addDeviceToQueue
 } from './queuehandler.js';
-import { addTestRunner, removeTestRunner } from './testrunners.js';
+import {
+  addTestRunner,
+  removeTestRunner,
+  touchTestRunner,
+  pruneStaleTestRunners
+} from './testrunners.js';
 import {
   testConnection,
   updateStatus,
@@ -65,8 +70,13 @@ async function setupTestRunnerQueue() {
   // Create the queue that handle testrunners
   processJob('testrunners', async job => {
     return new Promise(resolve => {
-      // The testrunner can send two different messages; either that the
-      // queue is starting or that the queue is shutting down.
+      // The testrunner can send three message types: start (new runner is
+      // up), stop (graceful shutdown) and heartbeat (still here). A runner
+      // that misses heartbeats long enough gets pruned server-side.
+      if (job.data.type === 'heartbeat') {
+        touchTestRunner(job.data.hostname);
+        return resolve();
+      }
       if (job.data.type === 'start') {
         logger.info(
           'Got a new testrunner %s : %j',
@@ -135,12 +145,23 @@ export class SitespeedioServer {
     await this.webserver.start();
     await setupTestRunnerQueue();
     await setupResultQueue();
+    // Periodically prune testrunners that have stopped heartbeating —
+    // crashes / OOM kills / host reboots never emit a graceful stop, so
+    // without this they'd stay registered forever and the metrics would
+    // lie.
+    this.pruneTimer = setInterval(pruneStaleTestRunners, 60_000);
+    this.pruneTimer.unref();
     // Tell the world that we are starting
     await publish('server', 'start');
   }
 
   async stop() {
     logger.info('Closing down server');
+
+    if (this.pruneTimer) {
+      clearInterval(this.pruneTimer);
+      this.pruneTimer = undefined;
+    }
 
     // Stop accepting new HTTP requests and drain the in-flight ones before
     // we tear down the database pool — otherwise a request mid-query will

--- a/server/src/testrunners.js
+++ b/server/src/testrunners.js
@@ -1,15 +1,35 @@
+import { getLogger } from '@sitespeed.io/log';
+
 import { testRunnersConnected } from './metrics.js';
+
+const logger = getLogger('sitespeedio.server');
 
 const testRunners = {};
 
+// A testrunner that hasn't published a heartbeat in this many ms is
+// considered dead. The testrunner side currently heartbeats every 30s, so
+// 120s of silence is "missed four in a row" — enough to be confident it's
+// gone and not just having a bad Redis blip.
+const STALE_AFTER_MS = 120_000;
+
+function queueNamesForConfig(config) {
+  return new Set(
+    (config.setup || [])
+      .map(s => s.queue)
+      .filter(name => typeof name === 'string' && name.length > 0)
+  );
+}
+
 function mergeByHostname(target, source) {
+  const now = Date.now();
   if (target[source.hostname]) {
     target[source.hostname].setup = [
       ...target[source.hostname].setup,
       ...source.setup
     ];
+    target[source.hostname].lastSeenAt = now;
   } else {
-    target[source.hostname] = { ...source };
+    target[source.hostname] = { ...source, firstSeenAt: now, lastSeenAt: now };
   }
 }
 
@@ -24,13 +44,62 @@ function updateTestRunnerMetrics() {
   }
 }
 
+// Warn when a new registration claims a queue name that a different
+// hostname is already serving. Bull will hand the work to whichever worker
+// it sees first and the operator gets no signal that two boxes are racing
+// for the same jobs.
+function warnOnQueueCollision(incoming) {
+  const incomingQueues = queueNamesForConfig(incoming);
+  if (incomingQueues.size === 0) return;
+  for (const existing of Object.values(testRunners)) {
+    if (existing.hostname === incoming.hostname) continue;
+    const existingQueues = queueNamesForConfig(existing);
+    for (const queue of incomingQueues) {
+      if (existingQueues.has(queue)) {
+        logger.error(
+          'Testrunner queue collision: %s and %s both claim queue %s. ' +
+            'Change LOCATION_NAME (or deviceId) on one of them.',
+          existing.hostname,
+          incoming.hostname,
+          queue
+        );
+      }
+    }
+  }
+}
+
 export function addTestRunner(config) {
+  warnOnQueueCollision(config);
   mergeByHostname(testRunners, config);
   updateTestRunnerMetrics();
 }
 
 export function removeTestRunner(config) {
   removeByHostname(config.hostname);
+  updateTestRunnerMetrics();
+}
+
+// Heartbeat handler: a known runner says "still here". Unknown runners
+// (heartbeat before the start message lands, or after a server-side prune)
+// are ignored — the next start broadcast will register them properly.
+export function touchTestRunner(hostname) {
+  const runner = testRunners[hostname];
+  if (runner) {
+    runner.lastSeenAt = Date.now();
+  }
+}
+
+export function pruneStaleTestRunners(now = Date.now()) {
+  for (const [hostname, runner] of Object.entries(testRunners)) {
+    if (now - (runner.lastSeenAt ?? 0) > STALE_AFTER_MS) {
+      logger.warn(
+        'Pruning stale testrunner %s (no heartbeat for %ds)',
+        hostname,
+        Math.round((now - runner.lastSeenAt) / 1000)
+      );
+      removeByHostname(hostname);
+    }
+  }
   updateTestRunnerMetrics();
 }
 

--- a/server/views/admin/index.pug
+++ b/server/views/admin/index.pug
@@ -28,6 +28,36 @@ html(lang='en')
     header(role='banner')
       h1 Admin
     main#main(role='main')
+      if testRunners && testRunners.length > 0
+        h2.section-heading Connected testrunners
+        .container(role='table' aria-label='Connected testrunners')
+          .row.row-head(role='row')
+            span.cell.idx(role='columnheader') #
+            span.cell.runner-host(role='columnheader') Hostname
+            span.cell.runner-loc(role='columnheader') Location
+            span.cell.runner-setup(role='columnheader') Setup
+            span.cell.runner-seen(role='columnheader') Last seen
+          each runner, runnerIndex in testRunners
+            -
+              var fresh = runner.secondsSinceSeen !== undefined && runner.secondsSinceSeen <= 60;
+              var stale = runner.secondsSinceSeen !== undefined && runner.secondsSinceSeen > 60;
+              var seenLabel = runner.secondsSinceSeen === undefined
+                ? 'unknown'
+                : runner.secondsSinceSeen < 60
+                  ? runner.secondsSinceSeen + 's ago'
+                  : Math.round(runner.secondsSinceSeen / 60) + 'm ago';
+            .row(role='row')
+              span.cell.idx(role='cell') #{runnerIndex+1}
+              code.cell.runner-host(role='cell') #{runner.hostname}
+              span.cell.runner-loc(role='cell') #{runner.location}
+              span.cell.runner-setup(role='cell')
+                each s, sIndex in (runner.setup || [])
+                  if sIndex > 0
+                    | ,
+                  |  #{s.type}/#{(s.browsers || []).join('+') || (s.deviceId || '?')}
+              span.cell.runner-seen(role='cell' class=(fresh ? 'is-fresh' : (stale ? 'is-stale' : '')))
+                | #{seenLabel}
+      h2.section-heading Queues
       .container(role='table' aria-label='Queue list')
         .row.row-head(role='row')
           span.cell.idx(role='columnheader') #

--- a/testrunner/src/sitespeedio-testrunner.js
+++ b/testrunner/src/sitespeedio-testrunner.js
@@ -14,6 +14,12 @@ const logger = getLogger('sitespeedio.testrunner');
 
 const queues = [];
 
+// Heartbeat cadence. The server prunes runners whose lastSeenAt is older
+// than 120 s (see server/src/testrunners.js), so 30 s gives us four chances
+// before we get marked dead.
+const HEARTBEAT_INTERVAL_MS = 30_000;
+let heartbeatTimer;
+
 export class SitespeedioTestRunner {
   constructor() {
     const logVerbose = nconf.get('log:verbose');
@@ -67,6 +73,18 @@ export class SitespeedioTestRunner {
 
     await queueHandler.start(serverConfig);
 
+    // Heartbeat. Reuses the existing `testrunners` queue used by start/stop;
+    // the server treats a missing heartbeat as a dead runner and prunes us.
+    const testRunnerQueue = await queueHandler.getQueue('testrunners');
+    heartbeatTimer = setInterval(() => {
+      testRunnerQueue
+        .add({ type: 'heartbeat', hostname: serverConfig.hostname })
+        .catch(error =>
+          logger.error('Failed to publish heartbeat: %s', error.message)
+        );
+    }, HEARTBEAT_INTERVAL_MS);
+    heartbeatTimer.unref();
+
     process.on('uncaughtException', error => {
       // ioredis configuration is tricky to get right
       // this can spam the log but at least we catch everything
@@ -75,6 +93,10 @@ export class SitespeedioTestRunner {
   }
 
   async stop() {
+    if (heartbeatTimer) {
+      clearInterval(heartbeatTimer);
+      heartbeatTimer = undefined;
+    }
     try {
       const serverConfig = nconf.get('location');
 


### PR DESCRIPTION
  Until now a fresh testrunner had to land in just the right configuration for the server to notice it, and if it
  crashed (OOM, host reboot, docker kill) it stayed registered forever — the admin page kept claiming it was alive and
  the Prometheus gauge counted ghosts. Two runners that picked the same LOCATION_NAME would silently race for the same
  Bull queue without any warning in the logs.

  Three changes close those gaps:

  - Every testrunner now heartbeats on the existing testrunners queue every 30 s. The server tracks lastSeenAt per runner and prunes anything quiet for more than 120 s, logging the prune so operators can grep. Crashed runners drop off the admin page within ~2 minutes and the connected-runners gauge stays honest.
  - When a new registration claims a queue name a different hostname is already serving, the server logs a clear error naming both hosts and the colliding queue. The registration still goes through — we don't want to break existing deployments — but the collision becomes loud instead of silent.
  - /admin grows a Connected testrunners section showing hostname, location, the setup each machine serves, and a fresh/stale "last seen" badge. PRODUCTION.md gets an "Adding a third (or Nth) testrunner" section with troubleshooting for the three failure modes you'll actually see: not registering, stale, and queue collision.

  Co-authored-by: Claude Opus 4.7 (1M context) noreply@anthropic.com