### PR TITLE
Show active / failed counts and a "no worker" badge on /admin

### DIFF
--- a/server/public/css/admin.css
+++ b/server/public/css/admin.css
@@ -144,7 +144,7 @@ main {
 
 .row {
   display: grid;
-  grid-template-columns: 48px 1fr 100px auto;
+  grid-template-columns: 48px 1fr 90px 80px 80px auto;
   align-items: center;
   gap: 14px;
   padding: 10px 16px;
@@ -187,19 +187,46 @@ main {
   font-weight: 500;
 }
 .cell.count.is-empty { color: var(--text-faint); }
-.cell.count.has-items {
+.cell.count.has-items,
+.cell.count.has-active,
+.cell.count.has-failed {
   color: var(--text);
   display: inline-flex;
   align-items: center;
   gap: 6px;
   justify-self: end;
 }
-.cell.count.has-items::before {
+.cell.count.has-items::before,
+.cell.count.has-active::before,
+.cell.count.has-failed::before {
   content: "";
   width: 6px; height: 6px;
   border-radius: 50%;
-  background: var(--primary);
   display: inline-block;
+}
+.cell.count.has-items::before { background: var(--primary); }
+.cell.count.has-active::before { background: var(--success, #0a7d36); }
+.cell.count.has-failed::before { background: var(--danger, #c0392b); }
+.cell.count.has-failed { color: var(--danger, #c0392b); }
+
+/* Inline pill that flags queues with pending work but no connected
+   testrunner. Sits next to the queue name in the same cell. */
+.cell.name .tag {
+  display: inline-block;
+  margin-left: 8px;
+  padding: 1px 8px;
+  font-family: var(--font-sans);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  border-radius: 999px;
+  border: 1px solid currentColor;
+  vertical-align: middle;
+}
+.cell.name .tag-warning {
+  color: var(--danger, #c0392b);
+  background: var(--danger-soft, rgba(192, 57, 43, 0.08));
 }
 
 .empty-btn {
@@ -248,19 +275,31 @@ footer {
 }
 footer p { margin: 0; }
 
-@media (max-width: 640px) {
-  .row {
-    grid-template-columns: 32px 1fr auto;
+@media (max-width: 700px) {
+  /* Narrow viewport: stack the queue row so the three counts share one
+     line below the queue name. Hide the header row entirely — the count
+     cells get inline labels via ::before instead. */
+  [aria-label='Queue list'] .row {
+    grid-template-columns: 32px 1fr;
     grid-template-areas:
-      "idx name count"
-      ".   action action";
-    row-gap: 8px;
+      "idx  name"
+      ".    counts"
+      ".    action";
+    row-gap: 6px;
   }
-  .cell.idx { grid-area: idx; }
-  .cell.name { grid-area: name; }
-  .cell.count { grid-area: count; }
-  .cell.action { grid-area: action; justify-self: end; }
-  .row-head .cell.action { display: none; }
+  [aria-label='Queue list'] .row-head { display: none; }
+  [aria-label='Queue list'] .cell.idx { grid-area: idx; }
+  [aria-label='Queue list'] .cell.name { grid-area: name; }
+  [aria-label='Queue list'] .cell.count {
+    grid-area: counts;
+    justify-self: start;
+  }
+  [aria-label='Queue list'] .cell.count + .cell.count { margin-left: 14px; }
+  /* Inline label so counts are still readable without the header. */
+  [aria-label='Queue list'] .cell.count.has-items::after { content: " pending"; opacity: 0.7; }
+  [aria-label='Queue list'] .cell.count.has-active::after { content: " active"; opacity: 0.7; }
+  [aria-label='Queue list'] .cell.count.has-failed::after { content: " failed"; opacity: 0.7; }
+  [aria-label='Queue list'] .cell.action { grid-area: action; justify-self: start; }
 }
 
 .section-heading {

--- a/server/src/queuehandler.js
+++ b/server/src/queuehandler.js
@@ -117,6 +117,25 @@ export async function getQueueSize(name) {
   return queue.count();
 }
 
+// Full job-counts view: waiting / active / failed / delayed / completed /
+// paused. The admin page uses waiting+active+failed; the other fields come
+// for free in the same Bull call so we expose them all.
+export async function getQueueCounts(name) {
+  const queue = getQueue(name);
+  try {
+    return await queue.getJobCounts();
+  } catch {
+    return {
+      waiting: 0,
+      active: 0,
+      failed: 0,
+      delayed: 0,
+      completed: 0,
+      paused: 0
+    };
+  }
+}
+
 export function getExistingQueue(name) {
   return queues[name];
 }

--- a/server/src/routes/html/admin/index.js
+++ b/server/src/routes/html/admin/index.js
@@ -5,17 +5,22 @@ import { getText } from '../../../util/text.js';
 import {
   getExistingQueue,
   getExistingQueueNames,
-  getQueueSize
+  getQueueCounts
 } from '../../../queuehandler.js';
 import { getTestRunners } from '../../../testrunners.js';
 
 export const admin = Router();
 
+// Internal queues created by the server itself for orchestration — they
+// don't have an external testrunner consuming them, so the "no worker"
+// badge would be misleading. Keep this list narrow.
+const INTERNAL_QUEUES = new Set(['testrunners', 'result']);
+
 async function buildAdminView() {
   const queues = getExistingQueueNames();
-  const queueSizes = {};
+  const queueCounts = {};
   for (const queueName of queues) {
-    queueSizes[queueName] = await getQueueSize(queueName);
+    queueCounts[queueName] = await getQueueCounts(queueName);
   }
   const now = Date.now();
   const testRunners = getTestRunners().map(runner => ({
@@ -27,11 +32,27 @@ async function buildAdminView() {
       ? Math.max(0, Math.round((now - runner.lastSeenAt) / 1000))
       : undefined
   }));
-  return { queues, queueSizes, testRunners };
+  // A queue is "served" if any currently-registered testrunner advertises
+  // it in its setup. Used to flag queues that have pending work but no
+  // worker — the most actionable thing an operator can see at a glance.
+  const servedQueues = new Set();
+  for (const runner of testRunners) {
+    for (const setup of runner.setup || []) {
+      if (setup.queue) servedQueues.add(setup.queue);
+    }
+  }
+  return {
+    queues,
+    queueCounts,
+    testRunners,
+    servedQueues,
+    internalQueues: INTERNAL_QUEUES
+  };
 }
 
 admin.get('/', async function (request, response) {
-  const { queues, queueSizes, testRunners } = await buildAdminView();
+  const { queues, queueCounts, testRunners, servedQueues, internalQueues } =
+    await buildAdminView();
   response.render('admin/index', {
     bodyId: 'index',
     title: getText('index.title'),
@@ -39,8 +60,10 @@ admin.get('/', async function (request, response) {
     nconf,
     getText,
     queues,
-    queueSizes,
-    testRunners
+    queueCounts,
+    testRunners,
+    servedQueues,
+    internalQueues
   });
 });
 
@@ -49,7 +72,8 @@ admin.post('/', async function (request, response) {
   const queue = await getExistingQueue(name);
   await queue.empty();
 
-  const { queues, queueSizes, testRunners } = await buildAdminView();
+  const { queues, queueCounts, testRunners, servedQueues, internalQueues } =
+    await buildAdminView();
   response.render('admin/index', {
     bodyId: 'index',
     title: getText('index.title'),
@@ -57,7 +81,9 @@ admin.post('/', async function (request, response) {
     nconf,
     getText,
     queues,
-    queueSizes,
-    testRunners
+    queueCounts,
+    testRunners,
+    servedQueues,
+    internalQueues
   });
 });

--- a/server/views/admin/index.pug
+++ b/server/views/admin/index.pug
@@ -63,18 +63,42 @@ html(lang='en')
           span.cell.idx(role='columnheader') #
           span.cell.name(role='columnheader') Queue
           span.cell.count(role='columnheader') Pending
+          span.cell.count(role='columnheader') Active
+          span.cell.count(role='columnheader') Failed
           span.cell.action(role='columnheader' aria-label='Actions')
         each queue, index in queues
+          -
+            var counts = (queueCounts && queueCounts[queue]) || {};
+            var pending = counts.waiting || 0;
+            var active = counts.active || 0;
+            var failed = counts.failed || 0;
+            var isInternal = internalQueues && internalQueues.has(queue);
+            var hasWorker = isInternal || (servedQueues && servedQueues.has(queue));
+            var showNoWorker = !isInternal && !hasWorker && pending > 0;
           .row(role='row')
             span.cell.idx(role='cell') #{index+1}
-            code.cell.name(role='cell') #{queue}
-            span.cell.count(role='cell' class=(queueSizes[queue] === 0 ? 'is-empty' : 'has-items'))
-              if queueSizes[queue] === 0
+            code.cell.name(role='cell')
+              | #{queue}
+              if showNoWorker
+                |
+                span.tag.tag-warning(title='No connected testrunner is serving this queue') no worker
+            span.cell.count(role='cell' class=(pending === 0 ? 'is-empty' : 'has-items'))
+              if pending === 0
                 | empty
               else
-                | #{queueSizes[queue]}
+                | #{pending}
+            span.cell.count(role='cell' class=(active === 0 ? 'is-empty' : 'has-active'))
+              if active === 0
+                | —
+              else
+                | #{active}
+            span.cell.count(role='cell' class=(failed === 0 ? 'is-empty' : 'has-failed'))
+              if failed === 0
+                | —
+              else
+                | #{failed}
             span.cell.action(role='cell')
-              button.empty-btn(onclick=`confirmAndSubmit('${queue}')` aria-label=`Empty queue ${queue}` disabled=(queueSizes[queue] === 0))
+              button.empty-btn(onclick=`confirmAndSubmit('${queue}')` aria-label=`Empty queue ${queue}` disabled=(pending === 0))
                 | Empty queue
     footer(role='contentinfo')
       p © 2026 sitespeed.io


### PR DESCRIPTION
  The admin page only showed pending count per queue, which is fine for "is
  anyone using this" but useless for "are these jobs actually getting picked
  up" or "are runs failing." Bull's getJobCounts() returns everything we
  need in one call, so the cost of surfacing more is one extra method on the
  queue helper.

  Three things appear now:

  - Active count per queue. Green dot when non-zero. The difference between "queue is moving" and "queue is stuck" at a glance.
  - Failed count per queue. Red dot and red number when non-zero, so a growing failure rate surfaces without trawling /result/ pages.
  - "No worker" pill next to the queue name when a queue has pending work but no currently-connected testrunner advertises it in its setup. Internal orchestration queues (testrunners, result) are excluded from the badge — they're consumed by the server itself, not by an external testrunner.

  The narrow-viewport media query is rebuilt for the new column count: at
  <700px the row stacks into name → counts (with inline labels) → action.

  Co-authored-by: Claude Opus 4.7 (1M context) noreply@anthropic.com