### PR TITLE
Show server health and currently-running tests on /admin

### DIFF
--- a/server/public/css/admin.css
+++ b/server/public/css/admin.css
@@ -372,6 +372,98 @@ footer p { margin: 0; }
   [aria-label='Connected testrunners'] .row-head { display: none; }
 }
 
+/* --- Health banner ---------------------------------------------------- */
+.health-bar {
+  max-width: 980px;
+  margin: 0 auto 22px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: center;
+  padding: 12px 14px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow-sm);
+}
+.health-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 10px;
+  font-family: var(--font-mono);
+  font-size: 12.5px;
+  font-weight: 500;
+  border-radius: 999px;
+  border: 1px solid var(--border);
+  background: var(--surface-2);
+  color: var(--text);
+}
+.health-pill .health-dot {
+  width: 7px; height: 7px;
+  border-radius: 50%;
+  background: var(--text-faint);
+}
+.health-pill.is-ok .health-dot { background: var(--success, #0a7d36); }
+.health-pill.is-ok { color: var(--success, #0a7d36); border-color: var(--success, #0a7d36); }
+.health-pill.is-down .health-dot { background: var(--danger, #c0392b); }
+.health-pill.is-down { color: var(--danger, #c0392b); border-color: var(--danger, #c0392b); }
+.health-pill.is-warning .health-dot { background: var(--warning, #b06400); }
+.health-pill.is-warning { color: var(--warning, #b06400); border-color: var(--warning, #b06400); }
+.health-pill.is-active { color: var(--success, #0a7d36); }
+.health-pill.is-failed { color: var(--danger, #c0392b); }
+.health-pill.is-neutral { color: var(--text-muted); }
+.health-version {
+  margin-left: auto;
+  font-family: var(--font-mono);
+  font-size: 12.5px;
+  color: var(--text-faint);
+}
+
+/* --- Currently-running tests ----------------------------------------- */
+[aria-label='Currently running tests'] .row {
+  grid-template-columns: 48px 110px 1fr 1fr 1fr 90px;
+}
+.cell.job-id {
+  font-family: var(--font-mono);
+  font-size: 13px;
+  word-break: break-all;
+}
+.cell.job-id a { color: var(--text); text-decoration: none; border-bottom: 1px dotted var(--text-faint); }
+.cell.job-id a:hover { color: var(--primary); border-bottom-color: var(--primary); }
+.cell.job-target {
+  font-size: 13.5px;
+  color: var(--text);
+  word-break: break-word;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.cell.job-queue, .cell.job-runner {
+  font-family: var(--font-mono);
+  font-size: 13px;
+  color: var(--text-2, var(--text));
+  word-break: break-all;
+}
+.cell.job-runner .text-faint { color: var(--text-faint); }
+.cell.job-elapsed {
+  font-family: var(--font-mono);
+  font-size: 13px;
+  text-align: right;
+  color: var(--text-muted);
+}
+.cell.job-elapsed.is-long {
+  color: var(--warning, #b06400);
+  font-weight: 600;
+}
+
+@media (max-width: 700px) {
+  [aria-label='Currently running tests'] .row {
+    grid-template-columns: 1fr;
+    gap: 4px;
+  }
+  [aria-label='Currently running tests'] .row-head { display: none; }
+}
+
 @media (prefers-reduced-motion: reduce) {
   *, *::before, *::after {
     animation-duration: 0.01ms !important;

--- a/server/src/database/index.js
+++ b/server/src/database/index.js
@@ -179,6 +179,20 @@ export async function getTestHar(id) {
   }
 }
 
+// Cheap one-shot DB ping for the admin health banner. Unlike
+// testConnection() (which retries with a 5s delay and is meant for
+// startup), this returns false fast on any failure so it won't stall
+// the admin page when Postgres is down.
+export async function isDatabaseHealthy() {
+  try {
+    const databaseHelper = DatabaseHelper.getInstance();
+    await databaseHelper.query('SELECT 1');
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 export async function testConnection(retries = 3, delay = 5000) {
   const test = 'SELECT 1 FROM sitespeed_io_test_runs';
   try {

--- a/server/src/queuehandler.js
+++ b/server/src/queuehandler.js
@@ -136,6 +136,30 @@ export async function getQueueCounts(name) {
   }
 }
 
+// Active jobs across a queue, capped so the admin call can't pull
+// thousands of records on a runaway. The job objects Bull returns are
+// heavy — the caller is expected to project only what it needs.
+export async function getActiveJobs(name, limit = 20) {
+  const queue = getQueue(name);
+  try {
+    return await queue.getActive(0, limit - 1);
+  } catch {
+    return [];
+  }
+}
+
+// Cheap health probe. Any open Bull queue exposes its underlying ioredis
+// client; status 'ready' means the connection is up and authenticated.
+// We pick the first connected queue — if none exist yet (very first
+// request after boot, before any testrunner has registered) we fall back
+// to 'unknown' rather than lying with 'down'.
+export function isRedisHealthy() {
+  for (const queue of Object.values(queues)) {
+    if (queue.client && queue.client.status === 'ready') return true;
+  }
+  return false;
+}
+
 export function getExistingQueue(name) {
   return queues[name];
 }

--- a/server/src/routes/html/admin/index.js
+++ b/server/src/routes/html/admin/index.js
@@ -1,3 +1,4 @@
+import { createRequire } from 'node:module';
 import { Router } from 'express';
 
 import { nconf } from '../../../config.js';
@@ -5,9 +6,15 @@ import { getText } from '../../../util/text.js';
 import {
   getExistingQueue,
   getExistingQueueNames,
-  getQueueCounts
+  getQueueCounts,
+  getActiveJobs,
+  isRedisHealthy
 } from '../../../queuehandler.js';
 import { getTestRunners } from '../../../testrunners.js';
+import { isDatabaseHealthy } from '../../../database/index.js';
+
+const require = createRequire(import.meta.url);
+const serverVersion = require('../../../../package.json').version;
 
 export const admin = Router();
 
@@ -32,58 +39,94 @@ async function buildAdminView() {
       ? Math.max(0, Math.round((now - runner.lastSeenAt) / 1000))
       : undefined
   }));
+  // Map every queue name to a hostname (if any) so the active-jobs table
+  // can show which testrunner picked up each job.
+  const queueToHostname = {};
+  for (const runner of testRunners) {
+    for (const setup of runner.setup || []) {
+      if (setup.queue && !queueToHostname[setup.queue]) {
+        queueToHostname[setup.queue] = runner.hostname;
+      }
+    }
+  }
   // A queue is "served" if any currently-registered testrunner advertises
   // it in its setup. Used to flag queues that have pending work but no
   // worker — the most actionable thing an operator can see at a glance.
-  const servedQueues = new Set();
-  for (const runner of testRunners) {
-    for (const setup of runner.setup || []) {
-      if (setup.queue) servedQueues.add(setup.queue);
+  const servedQueues = new Set(Object.keys(queueToHostname));
+  // Pull active (in-flight) jobs from each non-internal queue. Capped per
+  // queue so a runaway can't blow up the admin response.
+  const activeJobs = [];
+  for (const queueName of queues) {
+    if (INTERNAL_QUEUES.has(queueName)) continue;
+    const jobs = await getActiveJobs(queueName, 20);
+    for (const job of jobs) {
+      const startedAt = job.processedOn || job.timestamp;
+      activeJobs.push({
+        id: String(job.id),
+        queue: queueName,
+        url: job.data?.url || undefined,
+        scriptingName: job.data?.scriptingName || undefined,
+        label: job.data?.label || undefined,
+        runner: queueToHostname[queueName] || undefined,
+        startedAt,
+        secondsRunning: startedAt
+          ? Math.max(0, Math.round((now - startedAt) / 1000))
+          : undefined
+      });
     }
   }
+  activeJobs.sort((a, b) => (a.startedAt || 0) - (b.startedAt || 0));
+
+  // Health banner aggregates everything an operator wants at a glance.
+  let totalPending = 0;
+  let totalActive = 0;
+  let totalFailed = 0;
+  for (const queueName of queues) {
+    if (INTERNAL_QUEUES.has(queueName)) continue;
+    const c = queueCounts[queueName] || {};
+    totalPending += c.waiting || 0;
+    totalActive += c.active || 0;
+    totalFailed += c.failed || 0;
+  }
+  const health = {
+    serverVersion,
+    redis: isRedisHealthy(),
+    database: await isDatabaseHealthy(),
+    runnerCount: testRunners.length,
+    totalPending,
+    totalActive,
+    totalFailed
+  };
+
   return {
     queues,
     queueCounts,
     testRunners,
     servedQueues,
-    internalQueues: INTERNAL_QUEUES
+    internalQueues: INTERNAL_QUEUES,
+    activeJobs,
+    health
   };
 }
 
-admin.get('/', async function (request, response) {
-  const { queues, queueCounts, testRunners, servedQueues, internalQueues } =
-    await buildAdminView();
+function renderAdmin(response, view) {
   response.render('admin/index', {
     bodyId: 'index',
     title: getText('index.title'),
     description: getText('index.descripton'),
     nconf,
     getText,
-    queues,
-    queueCounts,
-    testRunners,
-    servedQueues,
-    internalQueues
+    ...view
   });
+}
+
+admin.get('/', async function (request, response) {
+  renderAdmin(response, await buildAdminView());
 });
 
 admin.post('/', async function (request, response) {
   const name = request.body.queueName;
   const queue = await getExistingQueue(name);
   await queue.empty();
-
-  const { queues, queueCounts, testRunners, servedQueues, internalQueues } =
-    await buildAdminView();
-  response.render('admin/index', {
-    bodyId: 'index',
-    title: getText('index.title'),
-    description: getText('index.descripton'),
-    nconf,
-    getText,
-    queues,
-    queueCounts,
-    testRunners,
-    servedQueues,
-    internalQueues
-  });
+  renderAdmin(response, await buildAdminView());
 });

--- a/server/views/admin/index.pug
+++ b/server/views/admin/index.pug
@@ -28,6 +28,21 @@ html(lang='en')
     header(role='banner')
       h1 Admin
     main#main(role='main')
+      if health
+        .health-bar(role='status' aria-label='Server status')
+          span.health-pill(class=(health.redis ? 'is-ok' : 'is-down') title='Redis / KeyDB connection')
+            span.health-dot
+            | Redis #{health.redis ? 'up' : 'down'}
+          span.health-pill(class=(health.database ? 'is-ok' : 'is-down') title='PostgreSQL connection')
+            span.health-dot
+            | DB #{health.database ? 'up' : 'down'}
+          span.health-pill(class=(health.runnerCount > 0 ? 'is-ok' : 'is-warning') title='Connected testrunners')
+            span.health-dot
+            | #{health.runnerCount} testrunner#{health.runnerCount === 1 ? '' : 's'}
+          span.health-pill.is-neutral(title='Jobs waiting across all queues') #{health.totalPending} pending
+          span.health-pill(class=(health.totalActive > 0 ? 'is-active' : 'is-neutral') title='Jobs running across all queues') #{health.totalActive} running
+          span.health-pill(class=(health.totalFailed > 0 ? 'is-failed' : 'is-neutral') title='Failed jobs across all queues') #{health.totalFailed} failed
+          span.health-version v#{health.serverVersion}
       if testRunners && testRunners.length > 0
         h2.section-heading Connected testrunners
         .container(role='table' aria-label='Connected testrunners')
@@ -57,6 +72,38 @@ html(lang='en')
                   |  #{s.type}/#{(s.browsers || []).join('+') || (s.deviceId || '?')}
               span.cell.runner-seen(role='cell' class=(fresh ? 'is-fresh' : (stale ? 'is-stale' : '')))
                 | #{seenLabel}
+      if activeJobs && activeJobs.length > 0
+        h2.section-heading Currently running
+        .container(role='table' aria-label='Currently running tests')
+          .row.row-head(role='row')
+            span.cell.idx(role='columnheader') #
+            span.cell.job-id(role='columnheader') Test
+            span.cell.job-target(role='columnheader') URL / script
+            span.cell.job-queue(role='columnheader') Queue
+            span.cell.job-runner(role='columnheader') Runner
+            span.cell.job-elapsed(role='columnheader') Running for
+          each job, jobIndex in activeJobs
+            -
+              var target = job.scriptingName || job.url || job.label || '(unknown)';
+              var elapsedLabel = job.secondsRunning === undefined
+                ? '—'
+                : job.secondsRunning < 60
+                  ? job.secondsRunning + 's'
+                  : Math.round(job.secondsRunning / 60) + 'm';
+              var longRunning = job.secondsRunning !== undefined && job.secondsRunning > 600;
+            .row(role='row')
+              span.cell.idx(role='cell') #{jobIndex+1}
+              code.cell.job-id(role='cell')
+                a(href='/result/' + job.id title='Open result page') #{job.id}
+              span.cell.job-target(role='cell') #{target}
+              code.cell.job-queue(role='cell') #{job.queue}
+              span.cell.job-runner(role='cell')
+                if job.runner
+                  code #{job.runner}
+                else
+                  span.text-faint —
+              span.cell.job-elapsed(role='cell' class=(longRunning ? 'is-long' : ''))
+                | #{elapsedLabel}
       h2.section-heading Queues
       .container(role='table' aria-label='Queue list')
         .row.row-head(role='row')


### PR DESCRIPTION
  The admin page told you how many jobs were waiting and which testrunners had registered, but nothing about whether
  the system was actually healthy or what work was in flight right now. So if results stopped landing, the first
  question — "is Redis up? is anyone running anything?" — required SSH and grep.

  Two new sections close that gap:

  A small health banner sits at the top of /admin with a Redis up/down pill, a Postgres up/down pill (cheap SELECT 1,
  returns fast on failure so the page doesn't stall when the DB is gone), the connected-testrunner count, and totals
  for pending/running/failed jobs across every non-internal queue. Server version is shown on the right edge. One
  glance answers "is anything obviously broken right now."

  Below the testrunner list, a Currently running table lists every active Bull job — test ID (clickable through to
  /result/), the URL or script name being tested, which queue it's on, which testrunner picked it up (correlated via
  the runner's advertised setup.queue), and how long it's been running. Anything over ten minutes turns amber so stuck
  runs are visible without scrolling. Jobs are capped at 20 per queue so a runaway queue can't blow up the admin
  response.

  The narrow-viewport stacking and reduced-motion media queries are extended to cover the new table.

  Co-authored-by: Claude Opus 4.7 (1M context) noreply@anthropic.com