### PR TITLE
Show recent failed jobs on /admin with one-click retry

### DIFF
--- a/server/public/css/admin.css
+++ b/server/public/css/admin.css
@@ -464,6 +464,73 @@ footer p { margin: 0; }
   [aria-label='Currently running tests'] .row-head { display: none; }
 }
 
+/* --- Recent failures table ------------------------------------------- */
+[aria-label='Recent failed tests'] .row {
+  grid-template-columns: 48px 110px 1fr 1.6fr 90px 80px;
+}
+.cell.fail-target {
+  font-size: 13.5px;
+  color: var(--text);
+  word-break: break-word;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.cell.fail-reason {
+  font-family: var(--font-mono);
+  font-size: 12.5px;
+  color: var(--danger, #c0392b);
+  word-break: break-word;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.cell.fail-when {
+  font-family: var(--font-mono);
+  font-size: 13px;
+  color: var(--text-muted);
+  text-align: right;
+}
+.retry-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-family: var(--font-sans);
+  font-weight: 500;
+  font-size: 13.5px;
+  padding: 6px 12px;
+  border: 1px solid var(--border-strong);
+  background: var(--surface);
+  color: var(--text);
+  cursor: pointer;
+  border-radius: var(--radius-sm);
+  transition: background .12s, border-color .12s, color .12s;
+  white-space: nowrap;
+}
+.retry-btn::before {
+  content: "↻";
+  font-family: var(--font-mono);
+  color: var(--text-faint);
+}
+.retry-btn:hover {
+  background: var(--primary-soft, rgba(0, 95, 204, 0.08));
+  border-color: var(--primary, #005fcc);
+  color: var(--primary, #005fcc);
+}
+.retry-btn:hover::before { color: var(--primary, #005fcc); }
+.retry-btn:focus-visible {
+  outline: 2px solid var(--primary, #005fcc);
+  outline-offset: 2px;
+}
+
+@media (max-width: 700px) {
+  [aria-label='Recent failed tests'] .row {
+    grid-template-columns: 1fr;
+    gap: 4px;
+  }
+  [aria-label='Recent failed tests'] .row-head { display: none; }
+  .cell.fail-reason { white-space: normal; }
+}
+
 @media (prefers-reduced-motion: reduce) {
   *, *::before, *::after {
     animation-duration: 0.01ms !important;

--- a/server/src/queuehandler.js
+++ b/server/src/queuehandler.js
@@ -148,6 +148,37 @@ export async function getActiveJobs(name, limit = 20) {
   }
 }
 
+// Most-recently-failed jobs from a queue. Bull keeps up to
+// `queue:removeOnFail` failures (defaults to 50, configurable in
+// server.yaml). The caller is expected to sort by `finishedOn` after
+// merging across queues.
+export async function getFailedJobs(name, limit = 20) {
+  const queue = getQueue(name);
+  try {
+    return await queue.getFailed(0, limit - 1);
+  } catch {
+    return [];
+  }
+}
+
+// Re-enqueue a previously-failed job via Bull's built-in retry. Returns
+// true on success, false if the job no longer exists or isn't in a
+// failed state (someone already retried it, or removeOnFail evicted it
+// between page render and click).
+export async function retryFailedJob(queueName, jobId) {
+  const queue = getQueue(queueName);
+  try {
+    const job = await queue.getJob(jobId);
+    if (!job) return false;
+    const state = await job.getState();
+    if (state !== 'failed') return false;
+    await job.retry();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 // Cheap health probe. Any open Bull queue exposes its underlying ioredis
 // client; status 'ready' means the connection is up and authenticated.
 // We pick the first connected queue — if none exist yet (very first

--- a/server/src/routes/html/admin/index.js
+++ b/server/src/routes/html/admin/index.js
@@ -8,6 +8,8 @@ import {
   getExistingQueueNames,
   getQueueCounts,
   getActiveJobs,
+  getFailedJobs,
+  retryFailedJob,
   isRedisHealthy
 } from '../../../queuehandler.js';
 import { getTestRunners } from '../../../testrunners.js';
@@ -77,6 +79,36 @@ async function buildAdminView() {
   }
   activeJobs.sort((a, b) => (a.startedAt || 0) - (b.startedAt || 0));
 
+  // Recent failures across non-internal queues. Bull's `failedReason` is
+  // the first line of whatever the testrunner threw. Truncate it for the
+  // table so a 4-line stack trace doesn't blow up the layout; the full
+  // log is one click away on /result/<id>.
+  const failedJobs = [];
+  for (const queueName of queues) {
+    if (INTERNAL_QUEUES.has(queueName)) continue;
+    const jobs = await getFailedJobs(queueName, 20);
+    for (const job of jobs) {
+      const finishedAt = job.finishedOn;
+      let reason = (job.failedReason || '').split('\n')[0].trim();
+      if (reason.length > 160) reason = reason.slice(0, 157) + '…';
+      failedJobs.push({
+        id: String(job.id),
+        queue: queueName,
+        target:
+          job.data?.scriptingName || job.data?.url || job.data?.label || '',
+        reason,
+        attemptsMade: job.attemptsMade || 0,
+        finishedAt,
+        secondsAgo: finishedAt
+          ? Math.max(0, Math.round((now - finishedAt) / 1000))
+          : undefined
+      });
+    }
+  }
+  failedJobs.sort((a, b) => (b.finishedAt || 0) - (a.finishedAt || 0));
+  // Show at most this many across all queues so the page stays scannable.
+  const recentFailures = failedJobs.slice(0, 25);
+
   // Health banner aggregates everything an operator wants at a glance.
   let totalPending = 0;
   let totalActive = 0;
@@ -105,6 +137,7 @@ async function buildAdminView() {
     servedQueues,
     internalQueues: INTERNAL_QUEUES,
     activeJobs,
+    failedJobs: recentFailures,
     health
   };
 }
@@ -129,4 +162,16 @@ admin.post('/', async function (request, response) {
   const queue = await getExistingQueue(name);
   await queue.empty();
   renderAdmin(response, await buildAdminView());
+});
+
+// Re-enqueue a failed job. Bull's job.retry() pushes it back to the
+// queue's wait list, so the next available testrunner on that queue
+// picks it up and runs it again — same data, same attempt counter.
+admin.post('/retry', async function (request, response) {
+  const queueName = request.body.queueName;
+  const jobId = request.body.jobId;
+  if (queueName && jobId) {
+    await retryFailedJob(queueName, jobId);
+  }
+  response.redirect('/admin/');
 });

--- a/server/views/admin/index.pug
+++ b/server/views/admin/index.pug
@@ -104,6 +104,38 @@ html(lang='en')
                   span.text-faint —
               span.cell.job-elapsed(role='cell' class=(longRunning ? 'is-long' : ''))
                 | #{elapsedLabel}
+      if failedJobs && failedJobs.length > 0
+        h2.section-heading Recent failures
+        .container(role='table' aria-label='Recent failed tests')
+          .row.row-head(role='row')
+            span.cell.idx(role='columnheader') #
+            span.cell.job-id(role='columnheader') Test
+            span.cell.fail-target(role='columnheader') URL / script
+            span.cell.fail-reason(role='columnheader') Reason
+            span.cell.fail-when(role='columnheader') When
+            span.cell.fail-action(role='columnheader' aria-label='Actions')
+          each job, failIndex in failedJobs
+            -
+              var whenLabel = job.secondsAgo === undefined
+                ? '—'
+                : job.secondsAgo < 60
+                  ? job.secondsAgo + 's ago'
+                  : job.secondsAgo < 3600
+                    ? Math.round(job.secondsAgo / 60) + 'm ago'
+                    : Math.round(job.secondsAgo / 3600) + 'h ago';
+            .row(role='row')
+              span.cell.idx(role='cell') #{failIndex+1}
+              code.cell.job-id(role='cell')
+                a(href='/result/' + job.id title='Open result page') #{job.id}
+              span.cell.fail-target(role='cell') #{job.target || '(unknown)'}
+              span.cell.fail-reason(role='cell' title=job.reason)
+                | #{job.reason || '(no reason recorded)'}
+              span.cell.fail-when(role='cell') #{whenLabel}
+              span.cell.fail-action(role='cell')
+                form(method='POST' action='/admin/retry' style='margin:0')
+                  input(type='hidden' name='queueName' value=job.queue)
+                  input(type='hidden' name='jobId' value=job.id)
+                  button.retry-btn(type='submit' aria-label=`Retry job ${job.id}`) Retry
       h2.section-heading Queues
       .container(role='table' aria-label='Queue list')
         .row.row-head(role='row')


### PR DESCRIPTION
  The admin page now shows what's failing, not just that something failed. Until now an operator who noticed a non-zero
   Failed count had to chase individual /result/ URLs by guessing IDs from the logs — there was nothing on the admin
  page to tell them which jobs failed, what went wrong, or how to retry.

  A new "Recent failures" section between Currently running and Queues lists the 25 most recent failed jobs across
  every non-internal queue. Each row shows the test ID (linking through to /result/ for the full log), the URL or
  scripting name that was being tested, the first line of Bull's failedReason (truncated to 160 chars so a long stack
  trace doesn't blow up the row), and how long ago the job failed. A Retry button on each row POSTs to a new
  /admin/retry endpoint that uses Bull's built-in job.retry() to push the same job back to the wait list — defended
  against double-clicks and removeOnFail evictions by checking the job's state before retrying.

  The section is conditional: a healthy day means the heading and table simply don't appear.

  Bull keeps up to queue.removeOnFail failures (default 50, server.yaml configurable), so there's already a natural cap
   on how far back this view can see.

  Co-authored-by: Claude Opus 4.7 (1M context) noreply@anthropic.com