### PR TITLE
Activity stats and an hourly chart on /admin

### DIFF
--- a/server/public/css/admin.css
+++ b/server/public/css/admin.css
@@ -427,6 +427,96 @@ footer p { margin: 0; }
   white-space: nowrap;
 }
 
+/* --- Activity stats + chart ----------------------------------------- */
+.stats-section {
+  max-width: 980px;
+  margin: 0 auto 28px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 16px 18px;
+  box-shadow: var(--shadow-sm);
+}
+.stats-strip {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 28px;
+  margin-bottom: 14px;
+}
+.stats-card {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 0;
+}
+.stats-card .stats-label {
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+.stats-card .stats-value {
+  font-family: var(--font-mono);
+  font-size: 28px;
+  font-weight: 600;
+  color: var(--text);
+  line-height: 1.05;
+}
+.stats-card .stats-pcts {
+  font-family: var(--font-mono);
+  font-size: 12.5px;
+  color: var(--text-muted);
+}
+.stats-card .stats-completed { color: var(--success, #0a7d36); }
+.stats-card .stats-failed { color: var(--danger, #c0392b); }
+
+.stats-chart {
+  margin: 0;
+}
+.stats-chart-svg {
+  display: block;
+  width: 100%;
+  height: 140px;
+}
+.stats-chart-axis {
+  stroke: var(--border, #d4d4d8);
+  stroke-width: 1;
+}
+.stats-chart-completed { fill: var(--success, #0a7d36); }
+.stats-chart-failed { fill: var(--danger, #c0392b); }
+.stats-chart-other { fill: var(--text-faint, #a1a1aa); }
+.stats-chart-tick {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  fill: var(--text-faint);
+}
+.stats-chart-legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  margin-top: 8px;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--text-muted);
+}
+.stats-chart-legend span::before {
+  content: "";
+  display: inline-block;
+  width: 10px; height: 10px;
+  margin-right: 6px;
+  border-radius: 2px;
+  vertical-align: middle;
+}
+.stats-legend-completed::before { background: var(--success, #0a7d36); }
+.stats-legend-failed::before { background: var(--danger, #c0392b); }
+.stats-legend-other::before { background: var(--text-faint, #a1a1aa); }
+.stats-chart-note {
+  margin-left: auto;
+  color: var(--text-faint);
+}
+.stats-chart-note::before { display: none; }
+
 /* --- Currently-running tests ----------------------------------------- */
 [aria-label='Currently running tests'] .row {
   grid-template-columns: 48px 110px 1fr 1fr 1fr 90px;

--- a/server/src/database/index.js
+++ b/server/src/database/index.js
@@ -193,6 +193,161 @@ export async function isDatabaseHealthy() {
   }
 }
 
+// Admin-page statistics: status breakdowns over 24 h and 7 d plus
+// hourly buckets for the activity chart. Cached for STATS_CACHE_TTL_MS
+// so the 15-second admin auto-refresh doesn't punish Postgres — the
+// numbers don't move fast enough to warrant a fresh query every tick.
+const STATS_CACHE_TTL_MS = 60_000;
+let statsCache;
+let statsCachedAt = 0;
+
+function emptyStatusTally() {
+  return { total: 0, completed: 0, failed: 0, active: 0, queued: 0, other: 0 };
+}
+
+const HOUR_MS = 3_600_000;
+
+function emptyStats() {
+  const buckets = [];
+  const startHour = new Date();
+  startHour.setMinutes(0, 0, 0);
+  for (let index = 23; index >= 0; index--) {
+    const t = new Date(startHour.getTime() - index * HOUR_MS);
+    buckets.push({
+      label: String(t.getHours()).padStart(2, '0'),
+      completed: 0,
+      failed: 0,
+      other: 0,
+      total: 0
+    });
+  }
+  return {
+    last24h: { ...emptyStatusTally(), pctCompleted: 0, pctFailed: 0 },
+    last7d: { ...emptyStatusTally(), pctCompleted: 0, pctFailed: 0 },
+    hourly: buckets
+  };
+}
+
+function tallyStatusRows(rows) {
+  const tally = emptyStatusTally();
+  for (const row of rows) {
+    const n = Number(row.count) || 0;
+    tally.total += n;
+    switch (row.status) {
+      case 'completed': {
+        tally.completed = n;
+        break;
+      }
+      case 'failed': {
+        tally.failed = n;
+        break;
+      }
+      case 'active': {
+        tally.active = n;
+        break;
+      }
+      case 'queued': {
+        tally.queued = n;
+        break;
+      }
+      default: {
+        tally.other += n;
+      }
+    }
+  }
+  tally.pctCompleted =
+    tally.total > 0 ? Math.round((tally.completed / tally.total) * 100) : 0;
+  tally.pctFailed =
+    tally.total > 0 ? Math.round((tally.failed / tally.total) * 100) : 0;
+  return tally;
+}
+
+function buildHourlyBuckets(rows) {
+  const byHour = {};
+  for (const row of rows) {
+    const t = row.hour instanceof Date ? row.hour : new Date(row.hour);
+    const key = t.toISOString();
+    if (!byHour[key]) {
+      byHour[key] = { completed: 0, failed: 0, other: 0 };
+    }
+    const n = Number(row.count) || 0;
+    switch (row.status) {
+      case 'completed': {
+        byHour[key].completed += n;
+        break;
+      }
+      case 'failed': {
+        byHour[key].failed += n;
+        break;
+      }
+      default: {
+        byHour[key].other += n;
+      }
+    }
+  }
+  const buckets = [];
+  const startHour = new Date();
+  startHour.setMinutes(0, 0, 0);
+  for (let index = 23; index >= 0; index--) {
+    const t = new Date(startHour.getTime() - index * HOUR_MS);
+    const key = t.toISOString();
+    const entry = byHour[key] || { completed: 0, failed: 0, other: 0 };
+    buckets.push({
+      label: String(t.getHours()).padStart(2, '0'),
+      completed: entry.completed,
+      failed: entry.failed,
+      other: entry.other,
+      total: entry.completed + entry.failed + entry.other
+    });
+  }
+  return buckets;
+}
+
+export async function getStatistics() {
+  const now = Date.now();
+  if (statsCache && now - statsCachedAt < STATS_CACHE_TTL_MS) {
+    return statsCache;
+  }
+  try {
+    const databaseHelper = DatabaseHelper.getInstance();
+    const [last24hResult, last7dResult, hourlyResult] = await Promise.all([
+      databaseHelper.query(
+        `SELECT status, COUNT(*)::int AS count
+           FROM sitespeed_io_test_runs
+          WHERE added_date >= NOW() - INTERVAL '24 hours'
+          GROUP BY status`
+      ),
+      databaseHelper.query(
+        `SELECT status, COUNT(*)::int AS count
+           FROM sitespeed_io_test_runs
+          WHERE added_date >= NOW() - INTERVAL '7 days'
+          GROUP BY status`
+      ),
+      databaseHelper.query(
+        `SELECT date_trunc('hour', added_date) AS hour,
+                status,
+                COUNT(*)::int AS count
+           FROM sitespeed_io_test_runs
+          WHERE added_date >= NOW() - INTERVAL '24 hours'
+          GROUP BY hour, status
+          ORDER BY hour`
+      )
+    ]);
+    statsCache = {
+      last24h: tallyStatusRows(last24hResult.rows),
+      last7d: tallyStatusRows(last7dResult.rows),
+      hourly: buildHourlyBuckets(hourlyResult.rows)
+    };
+    statsCachedAt = now;
+    return statsCache;
+  } catch (error) {
+    logError('Could not fetch admin statistics', error);
+    // Don't break /admin when stats fail — return the previous good
+    // value if we have one, otherwise zeros so the template renders.
+    return statsCache || emptyStats();
+  }
+}
+
 export async function testConnection(retries = 3, delay = 5000) {
   const test = 'SELECT 1 FROM sitespeed_io_test_runs';
   try {

--- a/server/src/routes/html/admin/index.js
+++ b/server/src/routes/html/admin/index.js
@@ -13,7 +13,7 @@ import {
   isRedisHealthy
 } from '../../../queuehandler.js';
 import { getTestRunners } from '../../../testrunners.js';
-import { isDatabaseHealthy } from '../../../database/index.js';
+import { isDatabaseHealthy, getStatistics } from '../../../database/index.js';
 
 const require = createRequire(import.meta.url);
 const serverVersion = require('../../../../package.json').version;
@@ -130,6 +130,10 @@ async function buildAdminView() {
     totalFailed
   };
 
+  // Pull DB-backed activity stats. The helper itself caches for 60s so
+  // the admin auto-refresh doesn't beat on Postgres every 15s.
+  const stats = await getStatistics();
+
   return {
     queues,
     queueCounts,
@@ -138,7 +142,8 @@ async function buildAdminView() {
     internalQueues: INTERNAL_QUEUES,
     activeJobs,
     failedJobs: recentFailures,
-    health
+    health,
+    stats
   };
 }
 

--- a/server/views/admin/index.pug
+++ b/server/views/admin/index.pug
@@ -112,6 +112,62 @@ html(lang='en')
           span.health-pill(class=(health.totalFailed > 0 ? 'is-failed' : 'is-neutral') title='Failed jobs across all queues') #{health.totalFailed} failed
           span.health-version v#{health.serverVersion}
           span.refresh-indicator#refresh-indicator(aria-live='polite' title='Page auto-refreshes every 15 seconds; pauses when the tab is hidden')
+      if stats
+        h2.section-heading Activity
+        .stats-section
+          .stats-strip
+            .stats-card
+              span.stats-label Last 24 hours
+              span.stats-value #{stats.last24h.total}
+              span.stats-pcts
+                span.stats-completed #{stats.last24h.pctCompleted}% completed
+                |  ·
+                span.stats-failed #{stats.last24h.pctFailed}% failed
+            .stats-card
+              span.stats-label Last 7 days
+              span.stats-value #{stats.last7d.total}
+              span.stats-pcts
+                span.stats-completed #{stats.last7d.pctCompleted}% completed
+                |  ·
+                span.stats-failed #{stats.last7d.pctFailed}% failed
+          -
+            // Stacked bar chart: one bar per hour for the last 24 h.
+            // Completed (green) sits on the baseline, failed (red) on
+            // top of completed, "other" (queued/active/etc) above that
+            // — read bottom-to-top as the test lifecycle.
+            var maxTotal = 1;
+            for (var b of stats.hourly) { if (b.total > maxTotal) maxTotal = b.total; }
+            var BAR_W = 26;
+            var STRIDE = 30;
+            var H = 110;
+          figure.stats-chart(role='figure' aria-label='Tests per hour over the last 24 hours')
+            svg.stats-chart-svg(width='100%' height='140' viewBox='0 0 720 140' preserveAspectRatio='xMinYMid meet')
+              line.stats-chart-axis(x1='0' y1='110' x2='720' y2='110')
+              each bucket, idx in stats.hourly
+                -
+                  var x = idx * STRIDE + 2;
+                  var completedH = Math.round(bucket.completed / maxTotal * H);
+                  var failedH = Math.round(bucket.failed / maxTotal * H);
+                  var otherH = Math.round(bucket.other / maxTotal * H);
+                  var yCompleted = 110 - completedH;
+                  var yFailed = yCompleted - failedH;
+                  var yOther = yFailed - otherH;
+                  var tooltip = bucket.label + ':00 — ' + bucket.total + ' tests (' + bucket.completed + ' completed, ' + bucket.failed + ' failed, ' + bucket.other + ' other)';
+                g
+                  title #{tooltip}
+                  if completedH > 0
+                    rect.stats-chart-completed(x=x y=yCompleted width=BAR_W height=completedH)
+                  if failedH > 0
+                    rect.stats-chart-failed(x=x y=yFailed width=BAR_W height=failedH)
+                  if otherH > 0
+                    rect.stats-chart-other(x=x y=yOther width=BAR_W height=otherH)
+                  if idx % 4 === 0 || idx === stats.hourly.length - 1
+                    text.stats-chart-tick(x=(x + BAR_W / 2) y='128' text-anchor='middle') #{bucket.label}
+            figcaption.stats-chart-legend
+              span.stats-legend-completed Completed
+              span.stats-legend-failed Failed
+              span.stats-legend-other Other
+              span.stats-chart-note Hourly buckets · last 24 h
       if testRunners && testRunners.length > 0
         h2.section-heading Connected testrunners
         .container(role='table' aria-label='Connected testrunners')


### PR DESCRIPTION
  Until now /admin showed point-in-time queue state but nothing about trend — you couldn't tell at a glance whether
  failures were climbing, whether the test rate had collapsed at 03:00, or how this hour compared to the rest of the
  day.

  A new "Activity" section between the health banner and the testrunner list pulls aggregates from
  sitespeed_io_test_runs:

  - Two stats cards summarise the last 24 hours and last 7 days — total tests run plus the completed/failed percentages.
  - A stacked bar chart shows tests-per-hour for the last 24 hours: completed in green, failed in red, everything else (queued / active / unknown) in muted grey on top. Pure server-rendered SVG, no JS or chart library, scales with the viewport. Hovering a bar shows the exact counts via the SVG <title> element. X-axis ticks every four hours.

  The three aggregations (24 h totals, 7 d totals, hourly buckets) run as one batch of parallel queries and are cached
  in memory for 60 seconds so the 15 s auto-refresh doesn't beat on Postgres. If the database fails the cache (or a
  zeroed fallback) is returned so the page still renders.

  Co-authored-by: Claude Opus 4.7 (1M context) noreply@anthropic.com