### PR TITLE
Stop long URLs from pushing the /search/ table off-centre

### DIFF
--- a/server/public/css/extra-console.css
+++ b/server/public/css/extra-console.css
@@ -760,6 +760,17 @@ td.run-date { white-space: nowrap; font-family: var(--font-mono); font-size: 13p
 .table td:first-child {
   font-family: var(--font-mono);
   font-size: 13.5px;
+  /* URLs in the first column can be long with sparse break points; let
+     them wrap at any character so they don't push the table past its
+     1100px container and shove the page off-centre on wide viewports. */
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+/* Safety net: if a row still demands more horizontal space than the
+   container can give it, scroll the table itself rather than the whole
+   page. Keeps the rest of the search UI centred. */
+#search-results-region form#search-form-compare {
+  overflow-x: auto;
 }
 
 .has-text-success { color: var(--success); font-weight: 500; }

--- a/server/public/css/extra-memphis.css
+++ b/server/public/css/extra-memphis.css
@@ -642,6 +642,18 @@ input[type="radio"]:not(.is-default):disabled {
 .table a { color: var(--ink); font-weight: 700; text-decoration: none; }
 .table a:hover { text-decoration: underline wavy var(--grape); }
 td.run-date { white-space: nowrap; }
+/* URLs in the first column can be very long with sparse break points;
+   let them wrap at any character so they don't push the table past its
+   container and shove the page off-centre. */
+.table td:first-child {
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+/* If a row still demands more space than the container has, scroll the
+   table itself rather than the whole page. */
+#search-results-region form#search-form-compare {
+  overflow-x: auto;
+}
 
 .has-text-success { color: var(--green); font-weight: 700; }
 .has-text-danger { color: var(--red); font-weight: 700; }


### PR DESCRIPTION
  The search results table sits inside a max-width: 1100px; margin: 0 auto; container, but border-collapse: collapse
  without table-layout: fixed lets a column grow to fit unbreakable content. A long Wikipedia URL with
  ?title=Special:UserLogin&returnto=Main+Page pushes the URL cell wider, the table outgrows its 1100 px container, and
  on wide viewports the table extends past the centred container's right edge while the rest of the page stays put —
  making the page look off-centre.

  shortURL(url, true) already crops to ~100 characters, but 100 characters of mostly-unbreakable text still wins.

  Two CSS-only tweaks, applied to both Console and Memphis themes:

  - overflow-wrap: anywhere (with word-break: break-word fallback) on the URL cell — long URLs now wrap at any character if no soft break is available.
  - overflow-x: auto on the search results form as a safety net — if a row ever demands more horizontal space than the container has, the table itself scrolls instead of pushing the whole page off-centre.

  Co-authored-by: Claude Opus 4.7 (1M context) noreply@anthropic.com