### PR TITLE
Show raw counts on /admin Activity, add 1 h and 30 d windows

### DIFF
--- a/server/src/database/index.js
+++ b/server/src/database/index.js
@@ -222,8 +222,10 @@ function emptyStats() {
     });
   }
   return {
-    last24h: { ...emptyStatusTally(), pctCompleted: 0, pctFailed: 0 },
-    last7d: { ...emptyStatusTally(), pctCompleted: 0, pctFailed: 0 },
+    lastHour: emptyStatusTally(),
+    last24h: emptyStatusTally(),
+    last7d: emptyStatusTally(),
+    last30d: emptyStatusTally(),
     hourly: buckets
   };
 }
@@ -255,10 +257,6 @@ function tallyStatusRows(rows) {
       }
     }
   }
-  tally.pctCompleted =
-    tally.total > 0 ? Math.round((tally.completed / tally.total) * 100) : 0;
-  tally.pctFailed =
-    tally.total > 0 ? Math.round((tally.failed / tally.total) * 100) : 0;
   return tally;
 }
 
@@ -310,7 +308,19 @@ export async function getStatistics() {
   }
   try {
     const databaseHelper = DatabaseHelper.getInstance();
-    const [last24hResult, last7dResult, hourlyResult] = await Promise.all([
+    const [
+      lastHourResult,
+      last24hResult,
+      last7dResult,
+      last30dResult,
+      hourlyResult
+    ] = await Promise.all([
+      databaseHelper.query(
+        `SELECT status, COUNT(*)::int AS count
+           FROM sitespeed_io_test_runs
+          WHERE added_date >= NOW() - INTERVAL '1 hour'
+          GROUP BY status`
+      ),
       databaseHelper.query(
         `SELECT status, COUNT(*)::int AS count
            FROM sitespeed_io_test_runs
@@ -324,6 +334,12 @@ export async function getStatistics() {
           GROUP BY status`
       ),
       databaseHelper.query(
+        `SELECT status, COUNT(*)::int AS count
+           FROM sitespeed_io_test_runs
+          WHERE added_date >= NOW() - INTERVAL '30 days'
+          GROUP BY status`
+      ),
+      databaseHelper.query(
         `SELECT date_trunc('hour', added_date) AS hour,
                 status,
                 COUNT(*)::int AS count
@@ -334,8 +350,10 @@ export async function getStatistics() {
       )
     ]);
     statsCache = {
+      lastHour: tallyStatusRows(lastHourResult.rows),
       last24h: tallyStatusRows(last24hResult.rows),
       last7d: tallyStatusRows(last7dResult.rows),
+      last30d: tallyStatusRows(last30dResult.rows),
       hourly: buildHourlyBuckets(hourlyResult.rows)
     };
     statsCachedAt = now;

--- a/server/views/admin/index.pug
+++ b/server/views/admin/index.pug
@@ -116,20 +116,18 @@ html(lang='en')
         h2.section-heading Activity
         .stats-section
           .stats-strip
-            .stats-card
-              span.stats-label Last 24 hours
-              span.stats-value #{stats.last24h.total}
-              span.stats-pcts
-                span.stats-completed #{stats.last24h.pctCompleted}% completed
-                |  ·
-                span.stats-failed #{stats.last24h.pctFailed}% failed
-            .stats-card
-              span.stats-label Last 7 days
-              span.stats-value #{stats.last7d.total}
-              span.stats-pcts
-                span.stats-completed #{stats.last7d.pctCompleted}% completed
-                |  ·
-                span.stats-failed #{stats.last7d.pctFailed}% failed
+            mixin stats-card(label, t)
+              .stats-card
+                span.stats-label= label
+                span.stats-value #{t.total}
+                span.stats-pcts
+                  span.stats-completed #{t.completed} completed
+                  |  ·
+                  span.stats-failed #{t.failed} failed
+            +stats-card('Last hour', stats.lastHour)
+            +stats-card('Last 24 hours', stats.last24h)
+            +stats-card('Last 7 days', stats.last7d)
+            +stats-card('Last 30 days', stats.last30d)
           -
             // Stacked bar chart: one bar per hour for the last 24 h.
             // Completed (green) sits on the baseline, failed (red) on


### PR DESCRIPTION
Two operator-visible problems with the activity strip on /admin: a single failure inside a few hundred completed tests rounded 1 / 400 * 100 down to 0%, so the page read "100% completed · 0% failed" even when failures were present in /search/; and the two existing windows (24 h, 7 d) flatten anything moving on the scale of minutes.

Each card now shows absolute counts ("400 tests · 398 completed · 2 failed") so even a single failure can't get rounded away. Two new windows fill in the time-scale gap: a 1-hour card for "what's happening right now", and a 30-day card for the long view past the existing weekly snapshot. All four cards use the same +stats-card mixin in the template so they stay symmetric.

The percentage math (pctCompleted / pctFailed) is dropped from the database helper since nothing consumes it anymore; the four window queries run together in one Promise.all and share the existing 60-second cache.

Co-authored-by: Claude Opus 4.7 (1M context) noreply@anthropic.com