### PR TITLE
Bump queue defaults to match proven prod values

### DIFF
--- a/server/config/server.yaml
+++ b/server/config/server.yaml
@@ -95,10 +95,14 @@ admin:
 
 # The number of jobs to keep in the queue
 # Depending on how many jobs you run and how much memory
-# you have on your Redis/KeyDb instance you can tune this
+# you have on your Redis/KeyDb instance you can tune this.
+# attempts controls how many times Bull will re-run a failed
+# job before giving up — 2 catches a single flaky network blip
+# without doubling load when a runner is truly broken.
 queue:
   removeOnComplete: 50
-  removeOnFail: 50
+  removeOnFail: 100
+  attempts: 2
 
 
 # The default sitspeed.io configuration file that will be merged to all tests.

--- a/server/src/util/add-test.js
+++ b/server/src/util/add-test.js
@@ -60,9 +60,9 @@ export async function reRunTest(request) {
 
   const queueName = getQueueName(oldTest.location, deviceId);
 
-  const removeOnComplete = nconf.get('queue:removeOnComplete') || 200;
-  const removeOnFail = nconf.get('queue:removeOnFail') || 400;
-  const attempts = nconf.get('queue:attempts') || 1;
+  const removeOnComplete = nconf.get('queue:removeOnComplete') || 50;
+  const removeOnFail = nconf.get('queue:removeOnFail') || 100;
+  const attempts = nconf.get('queue:attempts') || 2;
 
   if (queueName) {
     const testRunnerQueue = getExistingQueue(queueName);
@@ -146,9 +146,9 @@ export async function addTest(request) {
   const defaultConfig = await getDefaultSitespeedConfiguration();
 
   // The number of objects to keep in the queue before removal
-  const removeOnComplete = nconf.get('queue:removeOnComplete') || 200;
-  const removeOnFail = nconf.get('queue:removeOnFail') || 400;
-  const attempts = nconf.get('queue:attempts') || 1;
+  const removeOnComplete = nconf.get('queue:removeOnComplete') || 50;
+  const removeOnFail = nconf.get('queue:removeOnFail') || 100;
+  const attempts = nconf.get('queue:attempts') || 2;
   const userConfig = {
     browsertime: {
       browser,
@@ -267,9 +267,9 @@ export async function addTestFromAPI(
   dockerContainer
 ) {
   // The number of objects to keep in the queue before removal
-  const removeOnComplete = nconf.get('queue:removeOnComplete') || 200;
-  const removeOnFail = nconf.get('queue:removeOnFail') || 400;
-  const attempts = nconf.get('queue:attempts') || 1;
+  const removeOnComplete = nconf.get('queue:removeOnComplete') || 50;
+  const removeOnFail = nconf.get('queue:removeOnFail') || 100;
+  const attempts = nconf.get('queue:attempts') || 2;
 
   const deviceId =
     get(userConfig, 'browsertime.firefox.android.deviceSerial') ||


### PR DESCRIPTION
  removeOnFail goes from 50 to 100 — 50 was too small to keep useful
  context after a bad config push wipes a wave of jobs. attempts goes
  from "not set" (code default 1) to 2, so a single flaky network blip
  auto-recovers without doubling load when a runner is genuinely broken.

  The code-level || fallbacks in add-test.js were diverging from the
  yaml (200 / 400 / 1) which meant servers running without the config
  block silently got different behaviour. Aligned them to the new
  50 / 100 / 2.

  Co-authored-by: Claude noreply@anthropic.com