### PR TITLE
Bring /admin to life: per-queue sparklines and three small motions

### DIFF
--- a/server/public/css/admin.css
+++ b/server/public/css/admin.css
@@ -144,7 +144,7 @@ main {
 
 .row {
   display: grid;
-  grid-template-columns: 48px 1fr 90px 80px 80px auto;
+  grid-template-columns: 48px 1fr 110px 90px 80px 80px auto;
   align-items: center;
   gap: 14px;
   padding: 10px 16px;
@@ -278,7 +278,9 @@ footer p { margin: 0; }
 @media (max-width: 700px) {
   /* Narrow viewport: stack the queue row so the three counts share one
      line below the queue name. Hide the header row entirely — the count
-     cells get inline labels via ::before instead. */
+     cells get inline labels via ::before instead. The 24 h sparkline
+     drops off here; the count cells convey the same "alive or dead?"
+     signal on the small screen. */
   [aria-label='Queue list'] .row {
     grid-template-columns: 32px 1fr;
     grid-template-areas:
@@ -290,6 +292,7 @@ footer p { margin: 0; }
   [aria-label='Queue list'] .row-head { display: none; }
   [aria-label='Queue list'] .cell.idx { grid-area: idx; }
   [aria-label='Queue list'] .cell.name { grid-area: name; }
+  [aria-label='Queue list'] .cell.queue-spark { display: none; }
   [aria-label='Queue list'] .cell.count {
     grid-area: counts;
     justify-self: start;
@@ -628,9 +631,102 @@ footer p { margin: 0; }
   .cell.fail-reason { white-space: normal; }
 }
 
+/* --- Per-queue 24 h sparkline ----------------------------------------
+   Tiny inline trend chart on each queue row. Independently scaled per
+   queue (max = that queue's own 24 h peak), so a slow location and a
+   busy one both show meaningful shape. Aggregate signal only — the
+   exact count lives in the pending/active/failed cells. */
+.cell.queue-spark {
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+}
+.row-head .cell.queue-spark {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.04em;
+}
+.queue-spark-svg {
+  display: block;
+  width: 96px;
+  height: 20px;
+}
+.queue-spark-line {
+  fill: none;
+  stroke: var(--primary);
+  stroke-width: 1.25;
+  stroke-linejoin: round;
+  stroke-linecap: round;
+}
+.queue-spark-area {
+  fill: var(--primary);
+  opacity: 0.12;
+  stroke: none;
+}
+.queue-spark-empty {
+  font-family: var(--font-mono);
+  font-size: 14px;
+  color: var(--text-faint);
+}
+
+/* --- Animations ------------------------------------------------------
+   Three subtle motions, all gated by prefers-reduced-motion below:
+   1. Bar-chart entrance on first paint (staggered by --bar-i).
+   2. Refresh-indicator pulse fires on each fetch start.
+   3. data-rollup numbers tween from old to new in JS — no CSS needed
+      for the tween itself, but a brief color flash signals "this just
+      changed" so the eye knows where to land.
+*/
+
+/* 1) Bar-chart entrance. Each <g> sets --bar-i for the stagger and the
+      child <rect> inherits it for animation-delay. The gate on
+      body[data-stage="initial"] keeps the animation to first paint
+      only; the inline script clears the attr after ~1.2s. */
+.stats-chart-svg rect.bar-enter {
+  transform-origin: bottom;
+  transform-box: fill-box;
+}
+body[data-stage="initial"] .stats-chart-svg rect.bar-enter {
+  animation: bar-enter 520ms cubic-bezier(0.22, 0.61, 0.36, 1) both;
+  animation-delay: calc(var(--bar-i, 0) * 22ms);
+}
+@keyframes bar-enter {
+  from {
+    transform: scaleY(0);
+    opacity: 0;
+  }
+  to {
+    transform: scaleY(1);
+    opacity: 1;
+  }
+}
+
+/* 2) Refresh-indicator pulse. JS adds .is-refreshing on each fetch and
+      relies on a forced reflow to restart the animation. */
+.refresh-indicator.is-refreshing {
+  animation: refresh-pulse 700ms ease-out;
+}
+@keyframes refresh-pulse {
+  0%   { color: var(--text-faint); }
+  35%  { color: var(--primary); }
+  100% { color: var(--text-faint); }
+}
+
+/* 3) Rolling numbers — the value is driven from JS; the surrounding
+      pill gets a subtle accent for the duration of the rollup so the
+      eye is drawn to whichever counter changed.
+
+      Implementation note: we can't trigger a CSS animation reliably on
+      every text-content change, so we just use the JS rAF tween for
+      the value itself and rely on prefers-reduced-motion to short-
+      circuit (the tween still updates, but the duration is ~0). */
+
 @media (prefers-reduced-motion: reduce) {
   *, *::before, *::after {
     animation-duration: 0.01ms !important;
     transition-duration: 0.01ms !important;
+  }
+  body[data-stage="initial"] .stats-chart-svg rect.bar-enter {
+    animation: none !important;
   }
 }

--- a/server/src/database/index.js
+++ b/server/src/database/index.js
@@ -226,7 +226,8 @@ function emptyStats() {
     last24h: emptyStatusTally(),
     last7d: emptyStatusTally(),
     last30d: emptyStatusTally(),
-    hourly: buckets
+    hourly: buckets,
+    hourlyByLocation: {}
   };
 }
 
@@ -258,6 +259,35 @@ function tallyStatusRows(rows) {
     }
   }
   return tally;
+}
+
+// Per-location 24 h sparklines: one 24-element array of total counts
+// (all statuses summed) keyed by `location`. Drives the inline trend
+// preview on each queue row in /admin. We aggregate across status here
+// because the sparkline is a "is this queue alive?" indicator — a
+// 60×16 SVG isn't the place to read off completed vs. failed split.
+function buildHourlyByLocation(rows) {
+  const byLocHour = {};
+  for (const row of rows) {
+    const loc = row.location;
+    if (!loc) continue;
+    const t = row.hour instanceof Date ? row.hour : new Date(row.hour);
+    const key = t.toISOString();
+    if (!byLocHour[loc]) byLocHour[loc] = {};
+    byLocHour[loc][key] = (byLocHour[loc][key] || 0) + (Number(row.count) || 0);
+  }
+  const startHour = new Date();
+  startHour.setMinutes(0, 0, 0);
+  const result = {};
+  for (const [loc, hours] of Object.entries(byLocHour)) {
+    const buckets = [];
+    for (let index = 23; index >= 0; index--) {
+      const t = new Date(startHour.getTime() - index * HOUR_MS);
+      buckets.push(hours[t.toISOString()] || 0);
+    }
+    result[loc] = buckets;
+  }
+  return result;
 }
 
 function buildHourlyBuckets(rows) {
@@ -341,11 +371,12 @@ export async function getStatistics() {
       ),
       databaseHelper.query(
         `SELECT date_trunc('hour', added_date) AS hour,
+                location,
                 status,
                 COUNT(*)::int AS count
            FROM sitespeed_io_test_runs
           WHERE added_date >= NOW() - INTERVAL '24 hours'
-          GROUP BY hour, status
+          GROUP BY hour, location, status
           ORDER BY hour`
       )
     ]);
@@ -354,7 +385,8 @@ export async function getStatistics() {
       last24h: tallyStatusRows(last24hResult.rows),
       last7d: tallyStatusRows(last7dResult.rows),
       last30d: tallyStatusRows(last30dResult.rows),
-      hourly: buildHourlyBuckets(hourlyResult.rows)
+      hourly: buildHourlyBuckets(hourlyResult.rows),
+      hourlyByLocation: buildHourlyByLocation(hourlyResult.rows)
     };
     statsCachedAt = now;
     return statsCache;

--- a/server/src/routes/html/admin/index.js
+++ b/server/src/routes/html/admin/index.js
@@ -42,12 +42,19 @@ async function buildAdminView() {
       : undefined
   }));
   // Map every queue name to a hostname (if any) so the active-jobs table
-  // can show which testrunner picked up each job.
+  // can show which testrunner picked up each job. Also keep a queue ->
+  // location map so the queue-row sparkline can pull the right 24 h
+  // throughput slice (per-location is the closest signal we have
+  // without storing the queue name on each test row).
   const queueToHostname = {};
+  const queueToLocation = {};
   for (const runner of testRunners) {
     for (const setup of runner.setup || []) {
       if (setup.queue && !queueToHostname[setup.queue]) {
         queueToHostname[setup.queue] = runner.hostname;
+      }
+      if (setup.queue && !queueToLocation[setup.queue]) {
+        queueToLocation[setup.queue] = runner.location;
       }
     }
   }
@@ -134,6 +141,19 @@ async function buildAdminView() {
   // the admin auto-refresh doesn't beat on Postgres every 15s.
   const stats = await getStatistics();
 
+  // Per-queue sparkline arrays (24 hourly totals). Only filled for
+  // non-internal queues whose location we can resolve from a currently-
+  // connected runner — anything else gets no sparkline rather than a
+  // misleading flat line.
+  const queueSparklines = {};
+  for (const queueName of queues) {
+    if (INTERNAL_QUEUES.has(queueName)) continue;
+    const loc = queueToLocation[queueName];
+    if (!loc) continue;
+    const buckets = stats.hourlyByLocation && stats.hourlyByLocation[loc];
+    if (buckets) queueSparklines[queueName] = buckets;
+  }
+
   return {
     queues,
     queueCounts,
@@ -143,7 +163,8 @@ async function buildAdminView() {
     activeJobs,
     failedJobs: recentFailures,
     health,
-    stats
+    stats,
+    queueSparklines
   };
 }
 

--- a/server/views/admin/index.pug
+++ b/server/views/admin/index.pug
@@ -28,11 +28,19 @@ html(lang='en')
       // Pauses when the tab isn't visible (Page Visibility API) so we
       // don't keep hammering the server in background tabs. The "Updated
       // …s ago" indicator ticks every second between fetches.
+      //
+      // Visual feedback layered on top:
+      //   * data-rollup numbers are animated from their pre-swap value
+      //     to their post-swap value so the eye picks up "+1 pending"
+      //     instead of the number just teleporting.
+      //   * The refresh indicator pulses on each fetch start.
+      //   * body[data-stage="initial"] gates the bar-chart entrance so
+      //     it plays once on first paint, not on every refresh.
       (function () {
         var REFRESH_INTERVAL_MS = 15000;
+        var ROLLUP_MS = 420;
         var lastUpdatedAt = Date.now();
         var refreshing = false;
-        var intervalId = null;
 
         function setIndicator(text) {
           var el = document.getElementById('refresh-indicator');
@@ -44,9 +52,64 @@ html(lang='en')
           setIndicator(refreshing ? 'Updating…' : 'Updated ' + seconds + 's ago');
         }
 
+        function captureRollups() {
+          var map = {};
+          var nodes = document.querySelectorAll('[data-rollup]');
+          for (var i = 0; i < nodes.length; i++) {
+            var key = nodes[i].getAttribute('data-rollup');
+            var n = parseInt(nodes[i].textContent, 10);
+            map[key] = isNaN(n) ? 0 : n;
+          }
+          return map;
+        }
+
+        function prefersReducedMotion() {
+          return window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+        }
+
+        function animateNumber(el, from, to) {
+          if (prefersReducedMotion()) {
+            el.textContent = to;
+            return;
+          }
+          var start = performance.now();
+          function frame(now) {
+            var t = Math.min(1, (now - start) / ROLLUP_MS);
+            // easeOutCubic — quick start, gentle landing.
+            var eased = 1 - Math.pow(1 - t, 3);
+            el.textContent = Math.round(from + (to - from) * eased);
+            if (t < 1) requestAnimationFrame(frame);
+          }
+          requestAnimationFrame(frame);
+        }
+
+        function applyRollups(prevMap) {
+          var nodes = document.querySelectorAll('[data-rollup]');
+          for (var i = 0; i < nodes.length; i++) {
+            var el = nodes[i];
+            var key = el.getAttribute('data-rollup');
+            var to = parseInt(el.textContent, 10);
+            if (isNaN(to)) continue;
+            var from = prevMap[key];
+            if (from === undefined || from === to) continue;
+            animateNumber(el, from, to);
+          }
+        }
+
+        function pulseIndicator() {
+          var el = document.getElementById('refresh-indicator');
+          if (!el) return;
+          el.classList.remove('is-refreshing');
+          // Force a reflow so the animation restarts even if the class
+          // was just toggled off and on within the same tick.
+          void el.offsetWidth;
+          el.classList.add('is-refreshing');
+        }
+
         async function refresh() {
           if (document.hidden || refreshing) return;
           refreshing = true;
+          pulseIndicator();
           tickIndicator();
           try {
             var res = await fetch('/admin/', {
@@ -64,7 +127,9 @@ html(lang='en')
               // buttons don't "jump out" mid-tab.
               var active = document.activeElement;
               var activeId = active && active.id ? active.id : null;
+              var prevRollups = captureRollups();
               current.innerHTML = fresh.innerHTML;
+              applyRollups(prevRollups);
               if (activeId) {
                 var restored = document.getElementById(activeId);
                 if (restored && typeof restored.focus === 'function') {
@@ -84,14 +149,19 @@ html(lang='en')
         document.addEventListener('DOMContentLoaded', function () {
           tickIndicator();
           setInterval(tickIndicator, 1000);
-          intervalId = setInterval(refresh, REFRESH_INTERVAL_MS);
+          setInterval(refresh, REFRESH_INTERVAL_MS);
+          // Let the staggered bar-chart entrance finish, then drop the
+          // gate so subsequent refreshes don't replay it.
+          setTimeout(function () {
+            document.body.removeAttribute('data-stage');
+          }, 1200);
         });
 
         document.addEventListener('visibilitychange', function () {
           if (!document.hidden) refresh();
         });
       })();
-  body
+  body(data-stage='initial')
     a.skip-link(href='#main') Skip to content
     header(role='banner')
       h1 Admin
@@ -106,28 +176,39 @@ html(lang='en')
             | DB #{health.database ? 'up' : 'down'}
           span.health-pill(class=(health.runnerCount > 0 ? 'is-ok' : 'is-warning') title='Connected testrunners')
             span.health-dot
-            | #{health.runnerCount} testrunner#{health.runnerCount === 1 ? '' : 's'}
-          span.health-pill.is-neutral(title='Jobs waiting across all queues') #{health.totalPending} pending
-          span.health-pill(class=(health.totalActive > 0 ? 'is-active' : 'is-neutral') title='Jobs running across all queues') #{health.totalActive} running
-          span.health-pill(class=(health.totalFailed > 0 ? 'is-failed' : 'is-neutral') title='Failed jobs across all queues') #{health.totalFailed} failed
+            span(data-rollup='runnerCount')= health.runnerCount
+            |  testrunner#{health.runnerCount === 1 ? '' : 's'}
+          span.health-pill.is-neutral(title='Jobs waiting across all queues')
+            span(data-rollup='totalPending')= health.totalPending
+            |  pending
+          span.health-pill(class=(health.totalActive > 0 ? 'is-active' : 'is-neutral') title='Jobs running across all queues')
+            span(data-rollup='totalActive')= health.totalActive
+            |  running
+          span.health-pill(class=(health.totalFailed > 0 ? 'is-failed' : 'is-neutral') title='Failed jobs across all queues')
+            span(data-rollup='totalFailed')= health.totalFailed
+            |  failed
           span.health-version v#{health.serverVersion}
           span.refresh-indicator#refresh-indicator(aria-live='polite' title='Page auto-refreshes every 15 seconds; pauses when the tab is hidden')
       if stats
         h2.section-heading Activity
         .stats-section
           .stats-strip
-            mixin stats-card(label, t)
+            mixin stats-card(label, t, key)
               .stats-card
                 span.stats-label= label
-                span.stats-value #{t.total}
+                span.stats-value(data-rollup='stats-' + key + '-total')= t.total
                 span.stats-pcts
-                  span.stats-completed #{t.completed} completed
+                  span.stats-completed
+                    span(data-rollup='stats-' + key + '-completed')= t.completed
+                    |  completed
                   |  ·
-                  span.stats-failed #{t.failed} failed
-            +stats-card('Last hour', stats.lastHour)
-            +stats-card('Last 24 hours', stats.last24h)
-            +stats-card('Last 7 days', stats.last7d)
-            +stats-card('Last 30 days', stats.last30d)
+                  span.stats-failed
+                    span(data-rollup='stats-' + key + '-failed')= t.failed
+                    |  failed
+            +stats-card('Last hour', stats.lastHour, 'lastHour')
+            +stats-card('Last 24 hours', stats.last24h, 'last24h')
+            +stats-card('Last 7 days', stats.last7d, 'last7d')
+            +stats-card('Last 30 days', stats.last30d, 'last30d')
           -
             // Stacked bar chart: one bar per hour for the last 24 h.
             // Completed (green) sits on the baseline, failed (red) on
@@ -151,14 +232,14 @@ html(lang='en')
                   var yFailed = yCompleted - failedH;
                   var yOther = yFailed - otherH;
                   var tooltip = bucket.label + ':00 — ' + bucket.total + ' tests (' + bucket.completed + ' completed, ' + bucket.failed + ' failed, ' + bucket.other + ' other)';
-                g
+                g(style=`--bar-i: ${idx}`)
                   title #{tooltip}
                   if completedH > 0
-                    rect.stats-chart-completed(x=x y=yCompleted width=BAR_W height=completedH)
+                    rect.stats-chart-completed.bar-enter(x=x y=yCompleted width=BAR_W height=completedH)
                   if failedH > 0
-                    rect.stats-chart-failed(x=x y=yFailed width=BAR_W height=failedH)
+                    rect.stats-chart-failed.bar-enter(x=x y=yFailed width=BAR_W height=failedH)
                   if otherH > 0
-                    rect.stats-chart-other(x=x y=yOther width=BAR_W height=otherH)
+                    rect.stats-chart-other.bar-enter(x=x y=yOther width=BAR_W height=otherH)
                   if idx % 4 === 0 || idx === stats.hourly.length - 1
                     text.stats-chart-tick(x=(x + BAR_W / 2) y='128' text-anchor='middle') #{bucket.label}
             figcaption.stats-chart-legend
@@ -274,6 +355,7 @@ html(lang='en')
         .row.row-head(role='row')
           span.cell.idx(role='columnheader') #
           span.cell.name(role='columnheader') Queue
+          span.cell.queue-spark(role='columnheader' title='Tests added per hour over the last 24 h') 24 h
           span.cell.count(role='columnheader') Pending
           span.cell.count(role='columnheader') Active
           span.cell.count(role='columnheader') Failed
@@ -287,6 +369,25 @@ html(lang='en')
             var isInternal = internalQueues && internalQueues.has(queue);
             var hasWorker = isInternal || (servedQueues && servedQueues.has(queue));
             var showNoWorker = !isInternal && !hasWorker && pending > 0;
+            var spark = queueSparklines && queueSparklines[queue];
+            var sparkTotal = spark ? spark.reduce(function (a, b) { return a + b; }, 0) : 0;
+            var sparkPoints = '';
+            var sparkArea = '';
+            if (spark && sparkTotal > 0) {
+              var SP_W = 96, SP_H = 20, SP_PAD = 2;
+              var maxV = 1;
+              for (var v of spark) { if (v > maxV) maxV = v; }
+              var usable = SP_H - SP_PAD * 2;
+              var step = spark.length > 1 ? SP_W / (spark.length - 1) : 0;
+              var pts = [];
+              for (var i = 0; i < spark.length; i++) {
+                var px = (i * step).toFixed(1);
+                var py = (SP_PAD + (1 - spark[i] / maxV) * usable).toFixed(1);
+                pts.push(px + ',' + py);
+              }
+              sparkPoints = pts.join(' ');
+              sparkArea = '0,' + SP_H + ' ' + sparkPoints + ' ' + SP_W + ',' + SP_H;
+            }
           .row(role='row')
             span.cell.idx(role='cell') #{index+1}
             code.cell.name(role='cell')
@@ -294,6 +395,13 @@ html(lang='en')
               if showNoWorker
                 |
                 span.tag.tag-warning(title='No connected testrunner is serving this queue') no worker
+            span.cell.queue-spark(role='cell')
+              if sparkPoints
+                svg.queue-spark-svg(width='96' height='20' viewbox='0 0 96 20' preserveaspectratio='none' aria-label=`Last 24 h: ${sparkTotal} tests`)
+                  polyline.queue-spark-area(points=sparkArea)
+                  polyline.queue-spark-line(points=sparkPoints)
+              else
+                span.queue-spark-empty(title='No tests recorded for this queue in the last 24 h') —
             span.cell.count(role='cell' class=(pending === 0 ? 'is-empty' : 'has-items'))
               if pending === 0
                 | empty


### PR DESCRIPTION
  The admin page renders dense numbers that change every 15 s — the eye
  needs cues for "what just changed" and "is this queue alive?" Without
  them the page reads as static even when traffic is flowing.

  Added per-queue 24-hour sparklines so an operator can see at a glance
  which queues are busy and which are dead. The data comes from the
  existing hourly DB query, extended with a location group-by; the
  sparkline maps each queue to its location's 24-row slice via the live
  testrunner registry. Internal queues and queues with no resolvable
  location render a faint dash rather than a misleading flat line.

  Three motion cues on top: a one-time staggered bar-chart entrance on
  first paint, a brief color pulse on the refresh indicator each tick,
  and tweened number rollups on every metric so the eye lands on what
  moved. All gated by prefers-reduced-motion.

  Co-authored-by: Claude noreply@anthropic.com