### PR TITLE
 Quiet down /admin: stable refresh indicator, drop internal queues

### DIFF
--- a/server/public/css/admin.css
+++ b/server/public/css/admin.css
@@ -428,6 +428,14 @@ footer p { margin: 0; }
   color: var(--text-faint);
   margin-left: 6px;
   white-space: nowrap;
+  /* "Updated 14s ago" → "Updated 0s ago" loses a column once per cycle.
+     Without a stable width that one-character shrink reflows .health-
+     version (margin-left: auto) one column to the right every 15 s,
+     reading as a "shake" especially next to the refresh pulse. Pin to
+     the longest expected string so the indicator owns its slot. */
+  min-width: 15ch;
+  text-align: right;
+  display: inline-block;
 }
 
 /* --- Activity stats + chart ----------------------------------------- */

--- a/server/src/routes/html/admin/index.js
+++ b/server/src/routes/html/admin/index.js
@@ -154,8 +154,14 @@ async function buildAdminView() {
     if (buckets) queueSparklines[queueName] = buckets;
   }
 
+  // The Queues table is for operator-actionable queues only. Internal
+  // orchestration queues (testrunners, result) have no worker, no
+  // sparkline, no failure handling and an inert Empty button — showing
+  // them just adds rows you can't do anything with.
+  const visibleQueues = queues.filter(q => !INTERNAL_QUEUES.has(q));
+
   return {
-    queues,
+    queues: visibleQueues,
     queueCounts,
     testRunners,
     servedQueues,


### PR DESCRIPTION
  The "Updated Ns ago" counter is mono-font but its string length still
  changes (14→15 chars at the 9→10 boundary, back at 14→0), and because
  the version pill to its left has margin-left: auto, that one-column
  shrink reflowed the pill every 15 s. Once the pulse animation
  landed next to it, the wobble started reading as a shake. Pinning the
  indicator to its longest expected width keeps the slot stable.

  Internal queues (testrunners, result) were rendered as rows even
  though they're already excluded from totals, sparklines, and failure
  handling — the Empty button on them was inert too. They're operator-
  invisible work and only added noise. Filtering them out at the route
  boundary keeps the template untouched.

  Co-authored-by: Claude noreply@anthropic.com