### PR TITLE
Make the /admin "failed" pill a real health signal

### DIFF
--- a/server/src/routes/html/admin/index.js
+++ b/server/src/routes/html/admin/index.js
@@ -116,17 +116,29 @@ async function buildAdminView() {
   // Show at most this many across all queues so the page stays scannable.
   const recentFailures = failedJobs.slice(0, 25);
 
+  // Pull DB-backed activity stats first — the health banner uses the
+  // 24 h failed count from here. The helper itself caches for 60s so
+  // the admin auto-refresh doesn't beat on Postgres every 15s.
+  const stats = await getStatistics();
+
   // Health banner aggregates everything an operator wants at a glance.
+  // Pending/active are right-now Bull counts (truly ephemeral); failed
+  // is the last-24 h count from the DB rather than Bull's retained-
+  // failures count. Bull's count keeps every failure that hasn't been
+  // retried or evicted by `removeOnFail`, so it accumulates over weeks
+  // and never decays — that's a backlog, not a health signal. The
+  // Recent failures table on the same page is the place to see the
+  // retry backlog; the health pill should answer "did stuff break
+  // today?" and drop back to 0 when it didn't.
   let totalPending = 0;
   let totalActive = 0;
-  let totalFailed = 0;
   for (const queueName of queues) {
     if (INTERNAL_QUEUES.has(queueName)) continue;
     const c = queueCounts[queueName] || {};
     totalPending += c.waiting || 0;
     totalActive += c.active || 0;
-    totalFailed += c.failed || 0;
   }
+  const totalFailed = (stats.last24h && stats.last24h.failed) || 0;
   const health = {
     serverVersion,
     redis: isRedisHealthy(),
@@ -136,10 +148,6 @@ async function buildAdminView() {
     totalActive,
     totalFailed
   };
-
-  // Pull DB-backed activity stats. The helper itself caches for 60s so
-  // the admin auto-refresh doesn't beat on Postgres every 15s.
-  const stats = await getStatistics();
 
   // Per-queue sparkline arrays (24 hourly totals). Only filled for
   // non-internal queues whose location we can resolve from a currently-

--- a/server/views/admin/index.pug
+++ b/server/views/admin/index.pug
@@ -192,9 +192,9 @@ html(lang='en')
           span.health-pill(class=(health.totalActive > 0 ? 'is-active' : 'is-neutral') title='Jobs running across all queues')
             span(data-rollup='totalActive')= health.totalActive
             |  running
-          span.health-pill(class=(health.totalFailed > 0 ? 'is-failed' : 'is-neutral') title='Failed jobs across all queues')
+          span.health-pill(class=(health.totalFailed > 0 ? 'is-failed' : 'is-neutral') title='Tests that failed in the last 24 hours')
             span(data-rollup='totalFailed')= health.totalFailed
-            |  failed
+            |  failed · 24 h
           span.health-version v#{health.serverVersion}
           span.refresh-indicator#refresh-indicator(aria-live='polite' title='Page auto-refreshes every 15 seconds; pauses when the tab is hidden')
       if stats


### PR DESCRIPTION
  The failed count came from Bull's getJobCounts(), which returns the
  number of failed jobs Redis is still holding on to — capped by
  removeOnFail (100 per queue) and only shrinks when a job is retried
  successfully. So the pill accumulated weeks of stale failures and never
  decayed, even when nothing was currently broken. Misleading next to the
  activity cards, which use the DB and showed 0 failed in 24 h while the
  pill shouted "13 failed".

  Sourced the pill from the DB instead: last-24 h failed test runs. The
  backlog of retryable failures is still one click away in the Recent
  failures table; the health bar should answer "did stuff break today?"
  and drop back to 0 when it didn't.

  Co-authored-by: Claude noreply@anthropic.com