### PR TITLE
Bump default test engine to sitespeed.io 41 (3.8.0)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -119,8 +119,8 @@ LOCATION_NAME="default"
 
 # The sitespeed.io Docker image the testrunner uses to run tests.
 # Pin to a specific version for reproducibility in production.
-SITESPEED_IO_CONTAINER=sitespeedio/sitespeed.io:40
-# SITESPEED_IO_CONTAINER=sitespeedio/sitespeed.io:40.0.0
+SITESPEED_IO_CONTAINER=sitespeedio/sitespeed.io:41
+# SITESPEED_IO_CONTAINER=sitespeedio/sitespeed.io:41.0.0
 
 # The S3/MinIO endpoint as seen from inside the Docker network.
 # In Docker Compose this is the minio service name.

--- a/.github/workflows/docker-gui-scripting.yml
+++ b/.github/workflows/docker-gui-scripting.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Build testrunner
       run: docker build --load  --tag sitespeedio/testrunner:local-action -f ./testrunner/Dockerfile testrunner
     - name: Pull sitespeed.io
-      run: docker pull sitespeedio/sitespeed.io:40
+      run: docker pull sitespeedio/sitespeed.io:41
     - name: Prepare env
       run: cp .env.example .env
     - name: Start dependencies

--- a/.github/workflows/docker-gui.yml
+++ b/.github/workflows/docker-gui.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Build testrunner
       run: docker build --load  --tag sitespeedio/testrunner:local-action -f ./testrunner/Dockerfile testrunner
     - name: Pull sitespeed.io
-      run: docker pull sitespeedio/sitespeed.io:40
+      run: docker pull sitespeedio/sitespeed.io:41
     - name: Prepare env
       run: cp .env.example .env
     - name: Start dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 This changelog combines the server and testrunner changes. The changelog do [semantic versioning](https://semver.org).
 
+## 3.8.0 - 2026-05-15
+
+Picks up sitespeed.io 41 as the default test engine, plus a `/admin` accuracy fix and a vendored compare-bundle refresh.
+
+### Changed
+* Default sitespeed.io Docker image bumped from 40 to 41 in `.env.example`. The README "Update sitespeed.io version" snippets now reference 41 / 42 as the current and next-major tags.
+* Vendored compare bundle rolled to pagexray 5.0.0 (HTTP/3 detection, case-insensitive `Cache-Control` directives, `missingCompression` over-count fix). The bundle shrinks from ~28 KB to ~17 KB thanks to pagexray's switch from uglify-es to terser [#262](https://github.com/sitespeedio/onlinetest/pull/262).
+
+### Fixed
+* `/admin` "failed" pill is now a real health signal: it counts failed test runs in the last 24 h from Postgres instead of Bull's `getJobCounts()`, which was capped by `removeOnFail` and only decayed on a successful retry — so the pill accumulated weeks of stale failures and shouted "13 failed" next to activity cards that correctly showed 0 in 24 h [#261](https://github.com/sitespeedio/onlinetest/pull/261).
+* Compare cookie list no longer renders domains like `.example.com\nUIDR=...` when a HAR concatenates multiple `Set-Cookie` response headers into one newline-joined value — the next cookie's name was leaking into the previous cookie's `Domain=` attribute. Picked up via the pagexray bump [#262](https://github.com/sitespeedio/onlinetest/pull/262).
+
 ## 3.7.0 - 2026-05-13
 
 More `/admin` polish — per-queue trend lines, small motion cues, and a couple of testrunner re-registration fixes.

--- a/README.md
+++ b/README.md
@@ -115,16 +115,16 @@ There's a regular expression that validates the domain of the URL that you want 
 
 ### Update sitespeed.io version
 By default latest major release of sitespeed.io is configured, it looks like this in the **.env** file:
-`SITESPEED_IO_CONTAINER="sitespeedio/sitespeed.io:40"`
-
-When 41 is released you just switch to:
 `SITESPEED_IO_CONTAINER="sitespeedio/sitespeed.io:41"`
 
-To get latest version of 39 you need to periodically pull down the version:
-```docker pull sitespeedio/sitespeed.io:40```
+When 42 is released you just switch to:
+`SITESPEED_IO_CONTAINER="sitespeedio/sitespeed.io:42"`
+
+To get latest version of 41 you need to periodically pull down the version:
+```docker pull sitespeedio/sitespeed.io:41```
 
 If you want to run a specific version, you can pin the version to a specific version:
-`SITESPEED_IO_CONTAINER="sitespeedio/sitespeed.io:40.0.0"`
+`SITESPEED_IO_CONTAINER="sitespeedio/sitespeed.io:41.0.0"`
 
 #### Access the result
 Running on your own machine the result is served from localhost. If you deploy on a server you want to change that:


### PR DESCRIPTION
  Bring the default SITESPEED_IO_CONTAINER tag forward to the new major
  upstream, and re-anchor the README "Update sitespeed.io version" snippets and
  CI smoke-tests on the same tag so contributors and Actions don't drift back to
   40.

  This release also packages the two unreleased fixes that landed after 3.7.0:
  the /admin "failed" pill now reflects real recent-24h failures (instead of
  Bull's ever-growing retained-jobs count), and the vendored compare bundle gets
   pagexray's cookie / HTTP-3 / Cache-Control fixes.

  Co-authored-by: Claude Opus 4.7 (1M context) noreply@anthropic.com