### PR TITLE
Make first-run deploy a one-command install

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,7 +2,8 @@
 # ONLINETEST CONFIGURATION
 # ====================================
 # Source of truth for every variable the dev and production compose files read.
-# Copy this file to .env and change all CHANGE_ME passwords before starting.
+# For production single-server, `./deploy/update.sh --domain=...` will copy
+# this file to .env and auto-generate the passwords on first run.
 #
 # Three deployment shapes use this file:
 #

--- a/.env.example
+++ b/.env.example
@@ -28,13 +28,9 @@
 # ====================================
 # PASSWORDS
 # ====================================
-# Change all of these before first start.
-# Recommendation: Use at least 16 characters.
+# `./deploy/update.sh --domain=...` auto-generates these on first run.
+# If you fill them in by hand, use at least 16 characters.
 # Example generator: openssl rand -base64 24
-#
-# IMPORTANT: The Redis password must also be updated in redis-conf/redis.conf
-# (the "requirepass" line). Docker Compose mounts that file directly, so the
-# password in .env and redis.conf must match.
 REDIS_PASSWORD=CHANGE_ME_REDIS_PASSWORD
 POSTGRESQL_PASSWORD=CHANGE_ME_POSTGRES_PASSWORD
 MINIO_PASSWORD=CHANGE_ME_MINIO_PASSWORD

--- a/.env.example.local
+++ b/.env.example.local
@@ -22,10 +22,7 @@
 # ====================================
 # Change all of these before first start.
 # Recommendation: Use at least 16 characters.
-#
-# IMPORTANT: The Redis password must also be updated in redis-conf/redis.conf
-# (the "requirepass" line). Docker Compose mounts that file directly, so the
-# password in .env and redis.conf must match.
+# Example generator: openssl rand -base64 24
 REDIS_PASSWORD=CHANGE_ME_REDIS_PASSWORD
 POSTGRESQL_PASSWORD=CHANGE_ME_POSTGRES_PASSWORD
 MINIO_PASSWORD=CHANGE_ME_MINIO_PASSWORD

--- a/.github/workflows/deploy-script.yml
+++ b/.github/workflows/deploy-script.yml
@@ -22,14 +22,19 @@ jobs:
     - name: Verify .env state
       run: |
         set -e
-        if grep -q CHANGE_ME .env; then
-          echo "CHANGE_ME placeholders still present in .env:"
-          grep CHANGE_ME .env
+        if grep -qE '^[A-Z_]+=CHANGE_ME_' .env; then
+          echo "CHANGE_ME_* placeholders still present in .env:"
+          grep -E '^[A-Z_]+=CHANGE_ME_' .env
           exit 1
         fi
         grep -q "^DOMAIN=test.localhost$" .env
         grep -q '^RESULT_BASE_URL="https://test.localhost/sitespeedio"' .env
         grep -q '^SITESPEED.IO_HTML_HOMEURL="https://test.localhost/"' .env
+        # Exactly one line per derived variable (regression guard for the
+        # commented-out example duplicate that bit us in CI).
+        test "$(grep -cE '^DOMAIN=' .env)" = "1"
+        test "$(grep -cE '^RESULT_BASE_URL=' .env)" = "1"
+        test "$(grep -cE '^SITESPEED.IO_HTML_HOMEURL=' .env)" = "1"
     - name: Verify redis.conf has no requirepass
       run: |
         if grep -qE "^[[:space:]]*requirepass[[:space:]]" redis-conf/redis.conf; then

--- a/.github/workflows/deploy-script.yml
+++ b/.github/workflows/deploy-script.yml
@@ -1,0 +1,74 @@
+name: Deploy script
+on:
+  push:
+    branches:
+    - main
+  pull_request:
+    branches:
+    - main
+jobs:
+  install-logic:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Harden Runner
+      uses: step-security/harden-runner@5ef0c079ce82195b2a36a210272d6b661572d83e # v2.14.2
+      with:
+        egress-policy: audit
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+    - name: ShellCheck update.sh
+      run: shellcheck deploy/update.sh
+    - name: Run install (no-start)
+      run: ./deploy/update.sh --no-start --mode all-in-one --domain=test.localhost
+    - name: Verify .env state
+      run: |
+        set -e
+        if grep -q CHANGE_ME .env; then
+          echo "CHANGE_ME placeholders still present in .env:"
+          grep CHANGE_ME .env
+          exit 1
+        fi
+        grep -q "^DOMAIN=test.localhost$" .env
+        grep -q '^RESULT_BASE_URL="https://test.localhost/sitespeedio"' .env
+        grep -q '^SITESPEED.IO_HTML_HOMEURL="https://test.localhost/"' .env
+    - name: Verify redis.conf has no requirepass
+      run: |
+        if grep -qE "^[[:space:]]*requirepass[[:space:]]" redis-conf/redis.conf; then
+          echo "requirepass line found in redis-conf/redis.conf — should have been removed"
+          exit 1
+        fi
+    - name: Snapshot .env
+      run: cp .env .env.first-run
+    - name: Re-run install (idempotency)
+      run: ./deploy/update.sh --no-start
+    - name: Verify .env unchanged on re-run
+      run: diff .env .env.first-run
+
+  integration:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Harden Runner
+      uses: step-security/harden-runner@5ef0c079ce82195b2a36a210272d6b661572d83e # v2.14.2
+      with:
+        egress-policy: audit
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+    - name: Run install + start (all-in-one with internal TLS)
+      # test.localhost matches Caddy's automatic internal-CA rule, so Caddy
+      # issues a self-signed cert from its local CA without contacting
+      # Let's Encrypt. curl -k below ignores the resulting trust failure.
+      run: ./deploy/update.sh --mode all-in-one --domain=test.localhost
+    - name: Wait for HTTPS endpoint to respond
+      run: |
+        for i in $(seq 1 60); do
+          if curl -fsS --resolve test.localhost:443:127.0.0.1 -k https://test.localhost/api/ >/dev/null 2>&1; then
+            echo "Server reachable after ${i} attempts"
+            exit 0
+          fi
+          sleep 5
+        done
+        echo "Server did not respond on https://test.localhost/api/ in time"
+        exit 1
+    - name: Container status on failure
+      if: failure()
+      run: |
+        docker compose -f deploy/docker-compose.production.yml ps || true
+        docker compose -f deploy/docker-compose.production.yml logs --tail=200 || true

--- a/deploy/docker-compose.production-server.yml
+++ b/deploy/docker-compose.production-server.yml
@@ -1,7 +1,7 @@
 services:
   redis:
     image: redis:${REDIS_DOCKER_VERSION}
-    command: ["redis-server", "/usr/local/etc/redis/redis.conf"]
+    command: ["redis-server", "/usr/local/etc/redis/redis.conf", "--requirepass", "${REDIS_PASSWORD}"]
     restart: always
     ports:
       - "6379:6379"

--- a/deploy/docker-compose.production.yml
+++ b/deploy/docker-compose.production.yml
@@ -19,7 +19,7 @@ services:
         condition: service_healthy
   redis:
     image: redis:${REDIS_DOCKER_VERSION}
-    command: ["redis-server", "/usr/local/etc/redis/redis.conf"]
+    command: ["redis-server", "/usr/local/etc/redis/redis.conf", "--requirepass", "${REDIS_PASSWORD}"]
     restart: always
     networks:
       - skynet

--- a/deploy/update.sh
+++ b/deploy/update.sh
@@ -1,34 +1,46 @@
 #!/usr/bin/env bash
-# deploy/update.sh — pull the latest onlinetest images and restart services
-# in place. Use this on a production host instead of running `docker compose`
-# commands by hand.
+# deploy/update.sh — set up or update an onlinetest installation in place.
+#
+# First run on a fresh host:
+#   ./deploy/update.sh --domain=onlinetest.example.com
+#   (auto-generates secrets, writes .env, brings everything up)
+#
+# Every run after that:
+#   ./deploy/update.sh
+#   (pulls latest images, restarts services)
 #
 # Usage:
-#   ./deploy/update.sh [--mode all-in-one|server|testrunner] [--version X.Y.Z]
+#   ./deploy/update.sh [--mode all-in-one|server|testrunner]
+#                      [--domain DOMAIN] [--version X.Y.Z]
 #
 # Examples:
-#   ./deploy/update.sh                            # all-in-one, versions from .env
-#   ./deploy/update.sh --mode server              # server box (multi-server)
-#   ./deploy/update.sh --mode testrunner          # testrunner box (multi-server)
+#   ./deploy/update.sh --domain=foo.com           # first install (all-in-one)
+#   ./deploy/update.sh                            # subsequent update
+#   ./deploy/update.sh --mode server              # multi-server, server box
+#   ./deploy/update.sh --mode testrunner          # multi-server, testrunner box
 #   ./deploy/update.sh --version 3.4.0            # pin server & testrunner to 3.4.0
 #
 # Modes:
 #   all-in-one  — single host running Caddy + server + testrunner + deps.
-#                 Uses deploy/docker-compose.production.yml.
+#                 Uses deploy/docker-compose.production.yml. First-run install
+#                 (auto-generated secrets, DOMAIN prompt) only runs in this mode.
 #   server      — multi-server "server" host running deps + server only.
 #                 Uses deploy/docker-compose.production-server.yml.
 #   testrunner  — multi-server "testrunner" host.
 #                 Uses deploy/docker-compose.production-testrunner.yml.
 #
-# Requirements: docker, docker compose v2, .env at the repo root.
+# Requirements: docker, docker compose v2, .env at the repo root (auto-created
+# from .env.example on first run in all-in-one mode).
 
 set -euo pipefail
 
 MODE="all-in-one"
 VERSION=""
+DOMAIN_ARG=""
+NO_START=0
 
 usage() {
-  sed -n '2,24p' "$0" | sed 's/^# \{0,1\}//'
+  sed -n '2,33p' "$0" | sed 's/^# \{0,1\}//'
 }
 
 while [[ $# -gt 0 ]]; do
@@ -38,10 +50,34 @@ while [[ $# -gt 0 ]]; do
       if [ -z "$MODE" ]; then echo "--mode requires a value" >&2; exit 1; fi
       shift 2
       ;;
+    --mode=*)
+      MODE="${1#--mode=}"
+      shift
+      ;;
     --version)
       VERSION="${2:-}"
       if [ -z "$VERSION" ]; then echo "--version requires a value" >&2; exit 1; fi
       shift 2
+      ;;
+    --version=*)
+      VERSION="${1#--version=}"
+      shift
+      ;;
+    --domain)
+      DOMAIN_ARG="${2:-}"
+      if [ -z "$DOMAIN_ARG" ]; then echo "--domain requires a value" >&2; exit 1; fi
+      shift 2
+      ;;
+    --domain=*)
+      DOMAIN_ARG="${1#--domain=}"
+      shift
+      ;;
+    --no-start)
+      # Run the install steps (generate secrets, write .env, etc.) but skip
+      # `docker compose pull/up`. Useful for CI / inspecting the generated
+      # .env before bringing services up.
+      NO_START=1
+      shift
       ;;
     -h|--help)
       usage; exit 0
@@ -57,19 +93,233 @@ done
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$REPO_ROOT"
 
-if ! command -v docker >/dev/null 2>&1; then
-  echo "Error: docker not found in PATH" >&2
-  exit 1
-fi
-if ! docker compose version >/dev/null 2>&1; then
-  echo "Error: docker compose v2 not available (this script does not use docker-compose v1)" >&2
-  exit 1
-fi
-if [ ! -f .env ]; then
-  echo "Error: .env not found at $REPO_ROOT/.env" >&2
-  echo "       Copy .env.example to .env and fill in your secrets before running this." >&2
-  exit 1
-fi
+# ─── sanity checks ────────────────────────────────────────────────────────────
+
+require_docker() {
+  if ! command -v docker >/dev/null 2>&1; then
+    echo "Error: docker not found in PATH" >&2
+    echo "       Install docker: https://docs.docker.com/engine/install/" >&2
+    exit 1
+  fi
+  if ! docker compose version >/dev/null 2>&1; then
+    echo "Error: docker compose v2 not available (this script does not use docker-compose v1)" >&2
+    exit 1
+  fi
+}
+
+require_openssl() {
+  if ! command -v openssl >/dev/null 2>&1; then
+    echo "Error: openssl not found in PATH (needed to generate secrets on first run)" >&2
+    exit 1
+  fi
+}
+
+# ─── install-path helpers ─────────────────────────────────────────────────────
+
+# Echoes "install" if this looks like a first run (no .env, or any CHANGE_ME
+# placeholder still present); echoes "update" otherwise.
+detect_run_mode() {
+  if [ ! -f .env ]; then
+    echo install
+  elif grep -q 'CHANGE_ME' .env; then
+    echo install
+  else
+    echo update
+  fi
+}
+
+generate_secret() {
+  # base64 of 24 random bytes → 32 chars, alphabet [A-Za-z0-9+/=]. No newlines.
+  openssl rand -base64 24 | tr -d '\n'
+}
+
+# For every line of the form `VARNAME=CHANGE_ME_*` in .env, generate a fresh
+# secret and write it back atomically. Logs the variables that got filled in
+# so the user sees what happened. User-set values are preserved untouched.
+fill_env_placeholders() {
+  local tmp filled=() varname secret
+  tmp="$(mktemp "${REPO_ROOT}/.env.fill.XXXXXX")"
+  trap 'rm -f "$tmp"' RETURN
+
+  while IFS= read -r line || [ -n "$line" ]; do
+    if [[ "$line" =~ ^([A-Z_]+)=CHANGE_ME_ ]]; then
+      varname="${BASH_REMATCH[1]}"
+      secret="$(generate_secret)"
+      printf '%s=%s\n' "$varname" "$secret" >> "$tmp"
+      filled+=("$varname")
+    else
+      printf '%s\n' "$line" >> "$tmp"
+    fi
+  done < .env
+
+  mv "$tmp" .env
+  trap - RETURN
+
+  if [ "${#filled[@]}" -gt 0 ]; then
+    echo ">> Generated secrets for: ${filled[*]}"
+  fi
+}
+
+# Set DOMAIN=<value> in .env and derive RESULT_BASE_URL +
+# SITESPEED.IO_HTML_HOMEURL from it. Handles existing uncommented lines,
+# commented-out lines, and missing lines (append).
+set_env_domain() {
+  local value="$1" tmp
+  local result_url="https://${value}/sitespeedio"
+  local home_url="https://${value}/"
+
+  tmp="$(mktemp "${REPO_ROOT}/.env.dom.XXXXXX")"
+  trap 'rm -f "$tmp"' RETURN
+
+  local saw_domain=0 saw_result=0 saw_home=0
+  while IFS= read -r line || [ -n "$line" ]; do
+    if [[ "$line" =~ ^DOMAIN= ]] || [[ "$line" =~ ^[[:space:]]*#[[:space:]]*DOMAIN= ]]; then
+      printf 'DOMAIN=%s\n' "$value" >> "$tmp"
+      saw_domain=1
+    elif [[ "$line" =~ ^RESULT_BASE_URL= ]] || [[ "$line" =~ ^[[:space:]]*#[[:space:]]*RESULT_BASE_URL= ]]; then
+      printf 'RESULT_BASE_URL="%s"\n' "$result_url" >> "$tmp"
+      saw_result=1
+    elif [[ "$line" =~ ^SITESPEED\.IO_HTML_HOMEURL= ]] || [[ "$line" =~ ^[[:space:]]*#[[:space:]]*SITESPEED\.IO_HTML_HOMEURL= ]]; then
+      printf 'SITESPEED.IO_HTML_HOMEURL="%s"\n' "$home_url" >> "$tmp"
+      saw_home=1
+    else
+      printf '%s\n' "$line" >> "$tmp"
+    fi
+  done < .env
+
+  if [ "$saw_domain" -eq 0 ]; then printf 'DOMAIN=%s\n' "$value" >> "$tmp"; fi
+  if [ "$saw_result" -eq 0 ]; then printf 'RESULT_BASE_URL="%s"\n' "$result_url" >> "$tmp"; fi
+  if [ "$saw_home" -eq 0 ]; then printf 'SITESPEED.IO_HTML_HOMEURL="%s"\n' "$home_url" >> "$tmp"; fi
+
+  mv "$tmp" .env
+  trap - RETURN
+}
+
+# Echo the DOMAIN value to use: --domain flag wins, else interactive prompt.
+prompt_domain() {
+  if [ -n "$DOMAIN_ARG" ]; then
+    printf '%s' "$DOMAIN_ARG"
+    return
+  fi
+  local value=""
+  while [ -z "$value" ]; do
+    printf 'Enter the public domain for this onlinetest instance (e.g. onlinetest.example.com): ' >&2
+    if ! IFS= read -r value </dev/tty; then
+      echo "" >&2
+      echo "Error: cannot read DOMAIN interactively (no tty). Pass --domain=foo.com instead." >&2
+      exit 1
+    fi
+    if [ -z "$value" ]; then
+      echo "  (required — must not be empty)" >&2
+    fi
+  done
+  printf '%s' "$value"
+}
+
+# Read a value from .env. Echoes empty if the key isn't present.
+read_env() {
+  local key="$1"
+  if [ ! -f .env ]; then return; fi
+  grep -E "^${key}=" .env | head -1 | sed -e "s/^${key}=//" -e 's/^"//' -e 's/"$//'
+}
+
+# ─── version pin ──────────────────────────────────────────────────────────────
+
+pin_versions() {
+  local tmp
+  tmp="$(mktemp "${REPO_ROOT}/.env.update.XXXXXX")"
+  trap 'rm -f "$tmp"' RETURN
+  awk -v v="$VERSION" '
+    /^SITESPEED_IO_SERVER_VERSION=/ { print "SITESPEED_IO_SERVER_VERSION=" v; next }
+    /^SITESPEED_IO_TESTRUNNER_VERSION=/ { print "SITESPEED_IO_TESTRUNNER_VERSION=" v; next }
+    { print }
+  ' .env > "$tmp"
+  mv "$tmp" .env
+  trap - RETURN
+  echo "Pinned server/testrunner versions to $VERSION in .env"
+}
+
+# ─── compose actions ──────────────────────────────────────────────────────────
+
+compose_pull() {
+  echo ">> Pulling images (mode=$MODE)…"
+  docker compose "${COMPOSE_FILES[@]}" pull
+}
+
+compose_up() {
+  echo ">> Restarting services…"
+  docker compose "${COMPOSE_FILES[@]}" up -d --remove-orphans
+}
+
+compose_status() {
+  echo ">> Container status:"
+  docker compose "${COMPOSE_FILES[@]}" ps
+}
+
+compose_tail_logs() {
+  echo ">> Tailing logs for 10 seconds (Ctrl+C to keep watching)…"
+  # `timeout` returns 124 when it kills the process — that's the success path
+  # here, so swallow the non-zero exit. Plain `|| true` keeps `set -e` happy.
+  timeout 10 docker compose "${COMPOSE_FILES[@]}" logs --tail 30 -f || true
+}
+
+# ─── end-of-run messages ──────────────────────────────────────────────────────
+
+print_install_summary() {
+  local domain admin_login admin_pw valid_domains
+  domain="$(read_env DOMAIN)"
+  admin_login="$(read_env ADMIN_BASICAUTH_LOGIN)"
+  admin_pw="$(read_env ADMIN_BASICAUTH_PASSWORD)"
+  valid_domains="$(read_env VALID_TEST_DOMAINS)"
+
+  cat <<EOF
+
+================================================================
+ onlinetest installed.
+
+  Dashboard:        https://${domain}/
+  Admin URL:        https://${domain}/admin/
+  Admin login:      ${admin_login}
+  Admin password:   ${admin_pw}
+
+  (Generated secrets are stored in .env at the repo root.)
+
+  NEXT STEPS
+   - Point DNS for ${domain} at this server's IP. Caddy will issue a
+     Let's Encrypt cert on first request once DNS resolves.
+   - Test it: curl https://${domain}/api/
+EOF
+
+  if [ "$valid_domains" = ".*" ]; then
+    cat <<'EOF'
+
+  WARNING: VALID_TEST_DOMAINS is set to ".*" — your instance accepts test
+  submissions for ANY URL. If this server is reachable from the public
+  internet, you should either:
+    - set VALID_TEST_DOMAINS in .env to restrict (then rerun this script), or
+    - configure basicAuth in server/config/server.yaml, or
+    - configure api.key in server/config/server.yaml
+EOF
+  fi
+
+  echo "================================================================"
+}
+
+print_migration_hints() {
+  if [ -f redis-conf/redis.conf ] && grep -qE '^[[:space:]]*requirepass[[:space:]]' redis-conf/redis.conf; then
+    cat <<'EOF'
+
+  Note: redis-conf/redis.conf still contains a "requirepass" line.
+  The redis password is now passed via the docker-compose command line
+  and the config-file line is ignored. You can safely delete it from
+  redis-conf/redis.conf.
+EOF
+  fi
+}
+
+# ─── main flow ────────────────────────────────────────────────────────────────
+
+require_docker
 
 case "$MODE" in
   all-in-one)
@@ -87,35 +337,57 @@ case "$MODE" in
     ;;
 esac
 
-if [ -n "$VERSION" ]; then
-  # Rewrite the two version pins in .env atomically. awk handles the keys
-  # that already exist; we don't add them if they're missing, on the
-  # assumption the operator started from .env.example which already
-  # documents both.
-  TMP="$(mktemp "${REPO_ROOT}/.env.update.XXXXXX")"
-  trap 'rm -f "$TMP"' EXIT
-  awk -v v="$VERSION" '
-    /^SITESPEED_IO_SERVER_VERSION=/ { print "SITESPEED_IO_SERVER_VERSION=" v; next }
-    /^SITESPEED_IO_TESTRUNNER_VERSION=/ { print "SITESPEED_IO_TESTRUNNER_VERSION=" v; next }
-    { print }
-  ' .env > "$TMP"
-  mv "$TMP" .env
-  trap - EXIT
-  echo "Pinned server/testrunner versions to $VERSION in .env"
+RUN_MODE="$(detect_run_mode)"
+
+if [ "$RUN_MODE" = "install" ]; then
+  # The install path (auto-generate secrets, prompt for DOMAIN) only runs for
+  # all-in-one. server/testrunner boxes still need a hand-prepared .env that
+  # matches the server's secrets — that workflow is a separate piece of work.
+  if [ "$MODE" != "all-in-one" ]; then
+    if [ ! -f .env ]; then
+      echo "Error: .env not found at $REPO_ROOT/.env" >&2
+      echo "       For multi-server setups, copy .env from the server box and" >&2
+      echo "       adjust per deploy/PRODUCTION.md before running this script." >&2
+      exit 1
+    fi
+    echo "Warning: .env still contains CHANGE_ME placeholders. The install" >&2
+    echo "         flow only auto-fills these in --mode all-in-one. Fix .env" >&2
+    echo "         by hand or rerun with --mode all-in-one." >&2
+    exit 1
+  fi
+
+  require_openssl
+  echo ">> First run detected — installing onlinetest in all-in-one mode."
+  if [ ! -f .env ]; then
+    echo ">> Creating .env from .env.example"
+    cp .env.example .env
+  fi
+  DOMAIN_VALUE="$(prompt_domain)"
+  set_env_domain "$DOMAIN_VALUE"
+  fill_env_placeholders
+elif [ -n "$DOMAIN_ARG" ]; then
+  echo "Warning: --domain ignored — DOMAIN is already set in .env." >&2
+  echo "         To change it, edit .env and restart services." >&2
 fi
 
-echo ">> Pulling images (mode=$MODE)…"
-docker compose "${COMPOSE_FILES[@]}" pull
+if [ -n "$VERSION" ]; then
+  pin_versions
+fi
 
-echo ">> Restarting services…"
-docker compose "${COMPOSE_FILES[@]}" up -d --remove-orphans
+if [ "$NO_START" -eq 1 ]; then
+  echo ">> --no-start: skipping docker compose pull/up. .env is ready at $REPO_ROOT/.env."
+  exit 0
+fi
 
-echo ">> Container status:"
-docker compose "${COMPOSE_FILES[@]}" ps
+compose_pull
+compose_up
+compose_status
+compose_tail_logs
 
-echo ">> Tailing logs for 10 seconds (Ctrl+C to keep watching)…"
-# `timeout` returns 124 when it kills the process — that's the success path
-# here, so swallow the non-zero exit. Plain `|| true` keeps `set -e` happy.
-timeout 10 docker compose "${COMPOSE_FILES[@]}" logs --tail 30 -f || true
+if [ "$RUN_MODE" = "install" ]; then
+  print_install_summary
+else
+  print_migration_hints
+fi
 
 echo ">> Done."

--- a/deploy/update.sh
+++ b/deploy/update.sh
@@ -349,6 +349,13 @@ case "$MODE" in
     ;;
 esac
 
+# Compose v2 reads .env from the *project directory* (defaults to the dir of
+# the first -f file), not the CWD. The production compose files live under
+# deploy/ but .env is at the repo root — so we point compose at it explicitly.
+# Only do this once .env exists; on first run the install path creates it
+# before we ever call compose.
+COMPOSE_FILES=(--env-file .env "${COMPOSE_FILES[@]}")
+
 RUN_MODE="$(detect_run_mode)"
 
 if [ "$RUN_MODE" = "install" ]; then

--- a/deploy/update.sh
+++ b/deploy/update.sh
@@ -116,12 +116,14 @@ require_openssl() {
 
 # ─── install-path helpers ─────────────────────────────────────────────────────
 
-# Echoes "install" if this looks like a first run (no .env, or any CHANGE_ME
-# placeholder still present); echoes "update" otherwise.
+# Echoes "install" if this looks like a first run (no .env, or any
+# VARNAME=CHANGE_ME_… placeholder still present); echoes "update" otherwise.
+# The pattern is intentionally strict so comment text mentioning CHANGE_ME
+# (e.g. in .env.example's header) does not trigger an install loop.
 detect_run_mode() {
   if [ ! -f .env ]; then
     echo install
-  elif grep -q 'CHANGE_ME' .env; then
+  elif grep -qE '^[A-Z_]+=CHANGE_ME_' .env; then
     echo install
   else
     echo update
@@ -172,16 +174,26 @@ set_env_domain() {
   trap 'rm -f "$tmp"' RETURN
 
   local saw_domain=0 saw_result=0 saw_home=0
+  # .env.example may contain both an uncommented line and a commented example
+  # for the same variable. Replace only the first match for each variable;
+  # drop any subsequent matches so the resulting .env has exactly one line
+  # per variable.
   while IFS= read -r line || [ -n "$line" ]; do
     if [[ "$line" =~ ^DOMAIN= ]] || [[ "$line" =~ ^[[:space:]]*#[[:space:]]*DOMAIN= ]]; then
-      printf 'DOMAIN=%s\n' "$value" >> "$tmp"
-      saw_domain=1
+      if [ "$saw_domain" -eq 0 ]; then
+        printf 'DOMAIN=%s\n' "$value" >> "$tmp"
+        saw_domain=1
+      fi
     elif [[ "$line" =~ ^RESULT_BASE_URL= ]] || [[ "$line" =~ ^[[:space:]]*#[[:space:]]*RESULT_BASE_URL= ]]; then
-      printf 'RESULT_BASE_URL="%s"\n' "$result_url" >> "$tmp"
-      saw_result=1
+      if [ "$saw_result" -eq 0 ]; then
+        printf 'RESULT_BASE_URL="%s"\n' "$result_url" >> "$tmp"
+        saw_result=1
+      fi
     elif [[ "$line" =~ ^SITESPEED\.IO_HTML_HOMEURL= ]] || [[ "$line" =~ ^[[:space:]]*#[[:space:]]*SITESPEED\.IO_HTML_HOMEURL= ]]; then
-      printf 'SITESPEED.IO_HTML_HOMEURL="%s"\n' "$home_url" >> "$tmp"
-      saw_home=1
+      if [ "$saw_home" -eq 0 ]; then
+        printf 'SITESPEED.IO_HTML_HOMEURL="%s"\n' "$home_url" >> "$tmp"
+        saw_home=1
+      fi
     else
       printf '%s\n' "$line" >> "$tmp"
     fi

--- a/docker-compose.dependencies.yml
+++ b/docker-compose.dependencies.yml
@@ -1,7 +1,7 @@
 services:
   redis:
     image: redis:${REDIS_DOCKER_VERSION}
-    command: ["redis-server", "/usr/local/etc/redis/redis.conf"]
+    command: ["redis-server", "/usr/local/etc/redis/redis.conf", "--requirepass", "${REDIS_PASSWORD}"]
     restart: always
     networks:
       - skynet

--- a/redis-conf/redis.conf
+++ b/redis-conf/redis.conf
@@ -1,8 +1,9 @@
 # You can read more about keydb configuration: https://docs.keydb.dev/docs/config-file/
 # The default port
 port 6379
-# Your password, make sure to change this
-requirepass CHANGE_ME_REDIS_PASSWORD
+
+# The redis password is passed via the docker-compose command line
+# (--requirepass ${REDIS_PASSWORD}). It lives in .env, not here.
 
 # Choose max memory, adjust this to the server where you run keydb
 # You can also choose how many objects that should stay in keydb


### PR DESCRIPTION
  Today a fresh onlinetest deployment requires nine manual steps: clone, copy
  .env, change four CHANGE_ME passwords, set DOMAIN in three places, sync
  REDIS_PASSWORD into redis.conf, then run docker compose. The redis password
  sync in particular is a known footgun — the comment in .env.example calls it
  out explicitly, which is a tell that even the maintainer thinks it's annoying.

  This turns the path into "git clone && ./deploy/update.sh --domain=foo.com".
  update.sh detects a fresh install (no .env, or any CHANGE_ME line remaining),
  auto-generates all secrets with openssl, derives RESULT_BASE_URL and
  SITESPEED.IO_HTML_HOMEURL from DOMAIN, and prints the admin credential and a
  DNS reminder at the end. The redis password sync is eliminated by passing
  --requirepass ${REDIS_PASSWORD} via the compose command instead — redis.conf
  keeps its non-secret settings. Existing users who upgrade get a one-time
  migration hint about the now-ignored requirepass line.

  A new GitHub Action verifies both the install logic (no CHANGE_ME left,
  idempotency on re-run, redis.conf clean) and full all-in-one integration
  (Caddy with internal CA on test.localhost, /api/ reachable over HTTPS).

  Multi-runner onboarding is a separate piece of work — its design is captured
  in deploy/EASY_DEPLOY_PLAN.md alongside the rest of the resolved decisions
  and the deferred branches.

  Co-authored-by: Claude noreply@anthropic.com