### PR TITLE
Show run duration on hover in the search results table

### DIFF
--- a/server/src/database/search.js
+++ b/server/src/database/search.js
@@ -6,7 +6,7 @@ import DatabaseHelper from './databasehelper.js';
 const logger = getLogger('sitespeedio.database.search');
 
 const LIMITED_COLUMS =
-  'id, location, test_type, run_date, added_date, connectivity, browser_name, url, result_url, status, scripting_name, label, slug';
+  'id, location, test_type, run_date, added_date, finished_date, connectivity, browser_name, url, result_url, status, scripting_name, label, slug';
 
 /**
  *  Get a test by text (searching).

--- a/server/views/search.pug
+++ b/server/views/search.pug
@@ -421,7 +421,9 @@ block content
                           a(role='button' data-add='label:' + test.label title='Add label to search') #{test.label}
                         if nconf.get('search:showSlug') === true
                           a(role='button' data-add='slug:' + test.slug title='Add slug to search') #{test.slug}
-                    td.run-date #{dayjs(test.run_date?test.run_date:test.added_date).format(nconf.get('dateformat'))}
+                    - var runMs = (test.run_date && test.finished_date) ? (new Date(test.finished_date) - new Date(test.run_date)) : null;
+                    - var runLabel = (runMs != null && runMs >= 0) ? (runMs < 1000 ? runMs + 'ms' : runMs < 60000 ? (runMs/1000).toFixed(1) + 's' : Math.floor(runMs/60000) + 'm ' + Math.round((runMs%60000)/1000) + 's') : null;
+                    td.run-date(title=runLabel ? 'Run time: ' + runLabel : undefined) #{dayjs(test.run_date?test.run_date:test.added_date).format(nconf.get('dateformat'))}
                     td
                       a(role='button' data-add='location:' + test.location title='Add location to search') #{test.location}
                     td.is-capitalized


### PR DESCRIPTION
The "Run/added date" column told you when a test was queued or started, but not how long it actually ran. With the finished_date column from v4.0.0 we can now answer that on the same row. Hovering the cell shows "Run time: Xs" (or ms / Nm Ys at the extremes) for any completed or failed run from 4.0.0 onward. Older rows and currently-running tests keep no tooltip because finished_date is NULL for them.

Co-authored-by: Claude Sonnet 4.6 noreply@anthropic.com