### PR TITLE
Render screenshots, filmstrip and video on compare across origins

### DIFF
--- a/server/src/webserver.js
+++ b/server/src/webserver.js
@@ -121,7 +121,13 @@ function setupExpressServer() {
           defaultSrc: ["'self'"],
           scriptSrc: ["'self'", "'unsafe-inline'"],
           styleSrc: ["'self'", "'unsafe-inline'"],
-          imgSrc: ["'self'", 'data:'],
+          // Compare HARs carry absolute URLs to the screenshots, filmstrip
+          // frames and video on the originating sitespeed.io result server
+          // (`_meta.screenshot` / `_meta.filmstrip[].file` / `_meta.video`).
+          // Allow any HTTPS origin for those media types so cross-origin
+          // result servers render instead of showing empty image/video slots.
+          imgSrc: ["'self'", 'data:', 'https:'],
+          mediaSrc: ["'self'", 'https:'],
           fontSrc: ["'self'", 'data:'],
           connectSrc: ["'self'"],
           frameAncestors: ["'none'"],


### PR DESCRIPTION
  The compare page loads its HAR-derived screenshots, filmstrip frames
  and video from whatever sitespeed.io result server originally produced
  the HAR — typically a separate origin from the one running onlinetest
  itself. The helmet CSP only allowed 'self' for images and (implicitly,
  via default-src) for video, so those slots rendered empty whenever the
  HAR pointed at a different host. Relax img-src and add a media-src
  that allow any HTTPS origin so the compare view actually shows what the
  HAR captured.

  Co-authored-by: Claude noreply@anthropic.co